### PR TITLE
Improved DiffList

### DIFF
--- a/libGitWrap/ChangeListConsumer.cpp
+++ b/libGitWrap/ChangeListConsumer.cpp
@@ -27,7 +27,7 @@ namespace Git
     {
     }
 
-    bool ChangeListConsumer::raw( const ChangeListEntry &entry )
+    bool ChangeListConsumer::startFileChange( const ChangeListEntry &entry )
     {
         Q_UNUSED( entry );
 

--- a/libGitWrap/ChangeListConsumer.cpp
+++ b/libGitWrap/ChangeListConsumer.cpp
@@ -27,14 +27,9 @@ namespace Git
     {
     }
 
-    bool ChangeListConsumer::raw( const QString& oldPath, const QString& newPath, Type type,
-                                  unsigned int similarity, bool isBinary )
+    bool ChangeListConsumer::raw( const ChangeListEntry &entry )
     {
-        Q_UNUSED( oldPath );
-        Q_UNUSED( newPath );
-        Q_UNUSED( type );
-        Q_UNUSED( similarity );
-        Q_UNUSED( isBinary );
+        Q_UNUSED( entry );
 
         return false;
     }

--- a/libGitWrap/ChangeListConsumer.hpp
+++ b/libGitWrap/ChangeListConsumer.hpp
@@ -21,6 +21,7 @@
 
 namespace Git
 {
+    struct ChangeListEntry;
 
     /**
      * @ingroup     GitWrap
@@ -50,6 +51,19 @@ namespace Git
         virtual bool raw( const QString& oldPath, const QString& newPath, Type type,
                           unsigned int similarity, bool isBinary );
 
+    };
+
+    /**
+     * @ingroup GitWrap
+     * @brief The ChangeListEntry struct keeps information about a single file change.
+     */
+    struct ChangeListEntry
+    {
+        QString oldPath;
+        QString newPath;
+        ChangeListConsumer::Type type;
+        unsigned int similarity;
+        bool isBinary;
     };
 
 }

--- a/libGitWrap/ChangeListConsumer.hpp
+++ b/libGitWrap/ChangeListConsumer.hpp
@@ -48,7 +48,7 @@ namespace Git
         virtual ~ChangeListConsumer();
 
     public:
-        virtual bool raw( const ChangeListEntry &entry );
+        virtual bool startFileChange( const ChangeListEntry &entry );
 
     };
 

--- a/libGitWrap/ChangeListConsumer.hpp
+++ b/libGitWrap/ChangeListConsumer.hpp
@@ -56,7 +56,7 @@ namespace Git
      * @ingroup GitWrap
      * @brief The ChangeListEntry struct keeps information about a single file change.
      */
-    struct ChangeListEntry
+    struct GITWRAP_API ChangeListEntry
     {
         QString oldPath;
         QString newPath;

--- a/libGitWrap/ChangeListConsumer.hpp
+++ b/libGitWrap/ChangeListConsumer.hpp
@@ -48,8 +48,7 @@ namespace Git
         virtual ~ChangeListConsumer();
 
     public:
-        virtual bool raw( const QString& oldPath, const QString& newPath, Type type,
-                          unsigned int similarity, bool isBinary );
+        virtual bool raw( const ChangeListEntry &entry );
 
     };
 

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -22,11 +22,35 @@
 #include "RepositoryPrivate.hpp"
 #include "DiffListPrivate.hpp"
 
+
 namespace Git
 {
 
     namespace Internal
     {
+
+        class DiffListConsumer : public ChangeListConsumer
+        {
+        public:
+            bool raw(const Git::ChangeListEntry &entry);
+
+            const Git::ChangesList &changes() const;
+
+        private:
+            Git::ChangesList     mChanges;
+        };
+
+        bool DiffListConsumer::raw(const Git::ChangeListEntry &entry)
+        {
+            mChanges.append( entry );
+
+            return true;
+        }
+
+        const ChangesList &DiffListConsumer::changes() const
+        {
+            return mChanges;
+        }
 
         DiffListPrivate::DiffListPrivate( const GitPtr< RepositoryPrivate >& repo,
                                           git_diff_list* difflist )
@@ -267,6 +291,14 @@ namespace Git
                                    consumer );
 
         return result;
+    }
+
+    ChangesList DiffList::changes(Result &result)
+    {
+        Internal::DiffListConsumer consumer;
+        consumeChangeList(&consumer, result);
+
+        return consumer.changes();
     }
 
 }

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -34,10 +34,10 @@ namespace Git
         public:
             bool raw(const Git::ChangeListEntry &entry);
 
-            const Git::ChangesList &changes() const;
+            const Git::ChangeList &changeList() const;
 
         private:
-            Git::ChangesList     mChanges;
+            Git::ChangeList      mChanges;
         };
 
         bool DiffListConsumer::raw(const Git::ChangeListEntry &entry)
@@ -47,7 +47,7 @@ namespace Git
             return true;
         }
 
-        const ChangesList &DiffListConsumer::changes() const
+        const ChangeList &DiffListConsumer::changeList() const
         {
             return mChanges;
         }
@@ -293,12 +293,12 @@ namespace Git
         return result;
     }
 
-    ChangesList DiffList::changes(Result &result)
+    ChangeList DiffList::changeList(Result &result) const
     {
         Internal::DiffListConsumer consumer;
         consumeChangeList(&consumer, result);
 
-        return consumer.changes();
+        return consumer.changeList();
     }
 
 }

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -132,11 +132,16 @@ namespace Git
         {
             ChangeListConsumer* consumer = (ChangeListConsumer*) cb_data;
 
-            if( consumer->raw( QString::fromUtf8( delta->old_file.path ),
-                               QString::fromUtf8( delta->new_file.path ),
-                               ChangeListConsumer::Type( delta->status ),
-                               delta->similarity,
-                               delta->binary ) )
+            ChangeListEntry change =
+            {
+                QString::fromUtf8( delta->old_file.path )
+                , QString::fromUtf8( delta->new_file.path )
+                , ChangeListConsumer::Type( delta->status )
+                , delta->similarity
+                , delta->binary
+            };
+
+            if( consumer->raw( change ) )
             {
                 return GIT_OK;
             }

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -32,7 +32,7 @@ namespace Git
         class DiffListConsumer : public ChangeListConsumer
         {
         public:
-            bool raw(const Git::ChangeListEntry &entry);
+            bool startFileChange(const Git::ChangeListEntry &entry);
 
             const Git::ChangeList &changeList() const;
 
@@ -40,7 +40,7 @@ namespace Git
             Git::ChangeList      mChanges;
         };
 
-        bool DiffListConsumer::raw(const Git::ChangeListEntry &entry)
+        bool DiffListConsumer::startFileChange(const Git::ChangeListEntry &entry)
         {
             mChanges.append( entry );
 
@@ -83,7 +83,7 @@ namespace Git
                 , delta->binary
             };
 
-            if( pc->raw( entry ) )
+            if( pc->startFileChange( entry ) )
             {
                 return GIT_OK;
             }
@@ -98,9 +98,9 @@ namespace Git
         {
             PatchConsumer* pc = (PatchConsumer*) cb_data;
 
-            if( pc->startHunk( range->new_start, range->new_lines,
-                               range->old_start, range->old_lines,
-                               header ? QString::fromUtf8( header, int( header_len ) ) : QString() ) )
+            if( pc->startHunkChange( range->new_start, range->new_lines,
+                                     range->old_start, range->old_lines,
+                                     header ? QString::fromUtf8( header, int( header_len ) ) : QString() ) )
             {
                 return GIT_ERROR;
             }
@@ -170,7 +170,7 @@ namespace Git
                 , delta->binary
             };
 
-            if( consumer->raw( change ) )
+            if( consumer->startFileChange( change ) )
             {
                 return GIT_OK;
             }

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -74,16 +74,21 @@ namespace Git
         {
             PatchConsumer* pc = (PatchConsumer*) cb_data;
 
-            if( pc->startFile( QString::fromUtf8( delta->old_file.path ),
-                               QString::fromUtf8( delta->new_file.path ),
-                               PatchConsumer::Type( delta->status ),
-                               delta->similarity,
-                               delta->binary ) )
+            ChangeListEntry entry =
             {
-                return GIT_ERROR;
+                QString::fromUtf8( delta->old_file.path )
+                , QString::fromUtf8( delta->new_file.path )
+                , PatchConsumer::Type( delta->status )
+                , delta->similarity
+                , delta->binary
+            };
+
+            if( pc->raw( entry ) )
+            {
+                return GIT_OK;
             }
 
-            return GIT_OK;
+            return GIT_ERROR;
         }
 
         static int patchHunkCallBack( const git_diff_delta* delta,

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -30,10 +30,9 @@ namespace Git
     namespace Internal
     {
         class DiffListPrivate;
-        class DiffListConsumer;
     }
 
-    typedef QVector<ChangeListEntry> ChangesList;
+    typedef QVector<ChangeListEntry> ChangeList;
 
     /**
      * @ingroup     GitWrap
@@ -63,7 +62,7 @@ namespace Git
         bool consumeChangeList( ChangeListConsumer* consumer,
                                 Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 
-        ChangesList changes(Result& result);
+        ChangeList changeList(Result& result) const;
 
     private:
         Internal::GitPtr< Internal::DiffListPrivate > d;

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -24,12 +24,16 @@ namespace Git
 
     class Repository;
     class ChangeListConsumer;
+    struct ChangeListEntry;
     class PatchConsumer;
 
     namespace Internal
     {
         class DiffListPrivate;
+        class DiffListConsumer;
     }
+
+    typedef QVector<ChangeListEntry> ChangesList;
 
     /**
      * @ingroup     GitWrap
@@ -58,6 +62,8 @@ namespace Git
         bool consumePatch( PatchConsumer* consumer, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
         bool consumeChangeList( ChangeListConsumer* consumer,
                                 Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+
+        ChangesList changes(Result& result);
 
     private:
         Internal::GitPtr< Internal::DiffListPrivate > d;

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -20,6 +20,7 @@
 #include <QString>
 #include <QHash>
 #include <QMetaType>
+#include <QVector>
 
 /** @defgroup GitWrap Qt-based wrapper for Git revision control featuring libgit2
  * Wrapper for the LibGit2 library based on Qt4/Qt5.

--- a/libGitWrap/PatchConsumer.cpp
+++ b/libGitWrap/PatchConsumer.cpp
@@ -27,18 +27,6 @@ namespace Git
     {
     }
 
-    bool PatchConsumer::startFile( const QString& oldPath, const QString& newPath, Type type,
-                                   unsigned int similarity, bool isBinary )
-    {
-        Q_UNUSED( oldPath );
-        Q_UNUSED( newPath );
-        Q_UNUSED( type );
-        Q_UNUSED( similarity );
-        Q_UNUSED( isBinary );
-
-        return false;
-    }
-
     bool PatchConsumer::startHunk( int newStart, int newLines, int oldStart, int oldLines,
                                    const QString& header )
     {

--- a/libGitWrap/PatchConsumer.cpp
+++ b/libGitWrap/PatchConsumer.cpp
@@ -27,8 +27,8 @@ namespace Git
     {
     }
 
-    bool PatchConsumer::startHunk( int newStart, int newLines, int oldStart, int oldLines,
-                                   const QString& header )
+    bool PatchConsumer::startHunkChange( int newStart, int newLines, int oldStart, int oldLines,
+                                         const QString& header )
     {
         Q_UNUSED( newStart );
         Q_UNUSED( newLines );

--- a/libGitWrap/PatchConsumer.hpp
+++ b/libGitWrap/PatchConsumer.hpp
@@ -35,8 +35,8 @@ namespace Git
         virtual ~PatchConsumer();
 
     public:
-        virtual bool startHunk( int newStart, int newLines, int oldStart, int oldLines,
-                                const QString& header );
+        virtual bool startHunkChange( int newStart, int newLines, int oldStart, int oldLines,
+                                      const QString& header );
 
         virtual bool appendContext( const QString& content );
         virtual bool appendAddition( const QString& content );

--- a/libGitWrap/PatchConsumer.hpp
+++ b/libGitWrap/PatchConsumer.hpp
@@ -18,6 +18,7 @@
 #define GITWRAP_PATCH_CONSUMER_H
 
 #include "GitWrap.hpp"
+#include "ChangeListConsumer.hpp"
 
 namespace Git
 {
@@ -27,29 +28,13 @@ namespace Git
      * @brief       Callback interface to consume a list of differences
      *
      */
-    class GITWRAP_API PatchConsumer
+    class GITWRAP_API PatchConsumer : public ChangeListConsumer
     {
-    public:
-        enum Type
-        {
-            FileUnmodified,
-            FileAdded,
-            FileDeleted,
-            FileModified,
-            FileRenamed,
-            FileCopied,
-            FileIgnored,
-            FileUntracked
-        };
-
     public:
         PatchConsumer();
         virtual ~PatchConsumer();
 
     public:
-        virtual bool startFile( const QString& oldPath, const QString& newPath, Type type,
-                                unsigned int similarity, bool isBinary );
-
         virtual bool startHunk( int newStart, int newLines, int oldStart, int oldLines,
                                 const QString& header );
 


### PR DESCRIPTION
The DiffList now uses a ChangeListEntry struct instead of single variables in the callback. not sure about the `QVector<ChangeListEntry> DiffList::changes()` method. I'll try that out in one of the next commits.

Going further: Thinking about the PatchConsumer, it uses the same variables in the startFile() callback. It could use the same struct here, right? If so, I would like to change it in this PR.

Btw.: There was a little bug in the changeListCallBack() method a wrong handled bool. That caused only the first change to be noticed and returned an error after that -> Fixed it.
