### PR TITLE
feature: checkout commands

### DIFF
--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -287,7 +287,7 @@ namespace Git
     }
 
     /**
-     * @brief           Overwrites the file content with the conten from the index.
+     * @brief           Overwrites the file content with the content from the index.
      *
      * @param[in]       paths
      * @param[in,out]   result  A Result object; see @ref GitWrapErrorHandling
@@ -311,6 +311,8 @@ namespace Git
 
         git_checkout_opts options = GIT_CHECKOUT_OPTS_INIT;
         options.checkout_strategy = GIT_CHECKOUT_FORCE;
+
+        // TODO don't copy, just map paths here
         result = git_strarray_copy( &options.paths, Internal::StrArrayWrapper( paths ) );
         if ( !result )
             return;

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -287,6 +287,38 @@ namespace Git
     }
 
     /**
+     * @brief           Overwrites the file content with the conten from the index.
+     *
+     * @param[in]       paths
+     * @param[in,out]   result  A Result object; see @ref GitWrapErrorHandling
+     *
+     *                  Checkout the files to the index. File changes are discarded only in the
+     *                  working directory. Changes in the index stay untouched.
+     *                  This allows staging part of a file and discard the rest.
+     */
+    void Index::checkout(const QStringList &paths, Result &result)
+    {
+        if( !result )
+        {
+            return;
+        }
+
+        if( !d )
+        {
+            result.setInvalidObject();
+            return;
+        }
+
+        git_checkout_opts options = GIT_CHECKOUT_OPTS_INIT;
+        options.checkout_strategy = GIT_CHECKOUT_FORCE;
+        result = git_strarray_copy( &options.paths, Internal::StrArrayWrapper( paths ) );
+        if ( !result )
+            return;
+
+        result = git_checkout_index( d->repo()->mRepo, d->mIndex, &options );
+    }
+
+    /**
      * @brief           Read the index from storage
      *
      * Refills this index object with data obtained from hard disc. Any local modifications to this

--- a/libGitWrap/Index.hpp
+++ b/libGitWrap/Index.hpp
@@ -68,6 +68,8 @@ namespace Git
 
         void resetDefault(const QStringList &path, Result &result GITWRAP_DEFAULT_TLSRESULT);
 
+        void checkout( const QStringList &paths, Result &result GITWRAP_DEFAULT_TLSRESULT );
+
     private:
         Internal::GitPtr< Internal::IndexPrivate > d;
     };

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -341,7 +341,12 @@ namespace Git
         }
 
         git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+        opts.checkout_strategy = GIT_CHECKOUT_SAFE;
         result = git_checkout_tree( d->repo()->mRepo, d->mObj, &opts );
+        if ( !result ) return;
+
+        result = git_repository_set_head_detached( d->repo()->mRepo
+                                                   , git_object_id( d->mObj ) );
     }
 
     Reference ObjectCommit::createBranch( const QString& name, bool force, Result& result ) const

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -328,7 +328,7 @@ namespace Git
      *
      * @param[in,out]   result  A Result object; see @ref GitWrapErrorHandling
      */
-    void ObjectCommit::checkout(Result &result) const
+    void ObjectCommit::checkout(Result &result, bool force, const QStringList &paths) const
     {
         if( !result )
         {
@@ -341,7 +341,14 @@ namespace Git
         }
 
         git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
-        opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+        opts.checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
+        if ( !paths.isEmpty() )
+        {
+            // TODO: don't copy, just map paths here
+            result = git_strarray_copy( &opts.paths, Internal::StrArrayWrapper( paths ) );
+            if ( !result ) return;
+        }
+
         result = git_checkout_tree( d->repo()->mRepo, d->mObj, &opts );
         if ( !result ) return;
 

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -351,7 +351,7 @@ namespace Git
         }
 
         result = git_checkout_tree( d->repo()->mRepo, d->mObj, &opts );
-        if ( result && updateHEAD )
+        if ( updateHEAD )
             this->updateHEAD(result);
     }
 
@@ -427,6 +427,14 @@ namespace Git
 
     void ObjectCommit::updateHEAD(Result &result) const
     {
+        if ( !result ) return;
+
+        if ( !isValid() )
+        {
+            result.setInvalidObject();
+            return;
+        }
+
         result = git_repository_set_head_detached( d->repo()->mRepo
                                                    , git_object_id( d->mObj ) );
     }

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -323,6 +323,26 @@ namespace Git
         return QString::fromUtf8( msg, len );
     }
 
+    /**
+     * @brief           Checkout this commit.
+     *
+     * @param[in,out]   result  A Result object; see @ref GitWrapErrorHandling
+     */
+    void ObjectCommit::checkout(Result &result) const
+    {
+        if( !result )
+        {
+            return;
+        }
+        if( !d )
+        {
+            result.setInvalidObject();
+            return;
+        }
+
+        result = git_checkout_tree( d->repo()->mRepo, d->mObj, NULL );
+    }
+
     Reference ObjectCommit::createBranch( const QString& name, bool force, Result& result ) const
     {
         if( !result )

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -340,7 +340,8 @@ namespace Git
             return;
         }
 
-        result = git_checkout_tree( d->repo()->mRepo, d->mObj, NULL );
+        git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+        result = git_checkout_tree( d->repo()->mRepo, d->mObj, &opts );
     }
 
     Reference ObjectCommit::createBranch( const QString& name, bool force, Result& result ) const

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -328,7 +328,8 @@ namespace Git
      *
      * @param[in,out]   result  A Result object; see @ref GitWrapErrorHandling
      */
-    void ObjectCommit::checkout(Result &result, bool force, const QStringList &paths) const
+    void ObjectCommit::checkout(Result &result, bool force, bool updateHEAD,
+                                const QStringList &paths) const
     {
         if( !result )
         {
@@ -350,10 +351,8 @@ namespace Git
         }
 
         result = git_checkout_tree( d->repo()->mRepo, d->mObj, &opts );
-        if ( !result ) return;
-
-        result = git_repository_set_head_detached( d->repo()->mRepo
-                                                   , git_object_id( d->mObj ) );
+        if ( result && updateHEAD )
+            this->updateHEAD(result);
     }
 
     Reference ObjectCommit::createBranch( const QString& name, bool force, Result& result ) const
@@ -424,6 +423,12 @@ namespace Git
         }
 
         return dl;
+    }
+
+    void ObjectCommit::updateHEAD(Result &result) const
+    {
+        result = git_repository_set_head_detached( d->repo()->mRepo
+                                                   , git_object_id( d->mObj ) );
     }
 
 }

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -78,6 +78,7 @@ namespace Git
         QString message( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
         QString shortMessage( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 
+        void checkout( Result &result GITWRAP_DEFAULT_TLSRESULT ) const;
         Reference createBranch( const QString& name, bool force,
                                 Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -77,7 +77,7 @@ namespace Git
         QString message( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
         QString shortMessage( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 
-        void checkout( Result &result GITWRAP_DEFAULT_TLSRESULT,
+        void checkout( Result &result,
                        bool force = false,
                        const QStringList &paths = QStringList() ) const;
         Reference createBranch( const QString& name, bool force,

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -17,8 +17,7 @@
 #ifndef GIT_OBJECT_COMMIT_H
 #define GIT_OBJECT_COMMIT_H
 
-#include <QDebug>
-#include <QList>
+#include <QStringList>
 
 #include "GitWrap.hpp"
 #include "ObjectId.hpp"
@@ -78,7 +77,9 @@ namespace Git
         QString message( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
         QString shortMessage( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 
-        void checkout( Result &result GITWRAP_DEFAULT_TLSRESULT ) const;
+        void checkout( Result &result GITWRAP_DEFAULT_TLSRESULT,
+                       bool force = false,
+                       const QStringList &paths = QStringList() ) const;
         Reference createBranch( const QString& name, bool force,
                                 Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -79,12 +79,15 @@ namespace Git
 
         void checkout( Result &result,
                        bool force = false,
+                       bool updateHEAD = true,
                        const QStringList &paths = QStringList() ) const;
         Reference createBranch( const QString& name, bool force,
                                 Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
 
         DiffList diffFromParent( unsigned int index, Result& result GITWRAP_DEFAULT_TLSRESULT );
         DiffList diffFromAllParents( Result& result GITWRAP_DEFAULT_TLSRESULT );
+
+        void updateHEAD(Result &result) const;
     };
 
     /**

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -197,7 +197,7 @@ namespace Git
         return resolvedRef.objectId( result );
     }
 
-    void Reference::checkout(Result &result) const
+    void Reference::checkout(Result &result, bool force, const QStringList &paths) const
     {
         if (  !result )
         {
@@ -215,7 +215,13 @@ namespace Git
         if ( !result ) return;
 
         git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
-        opts.checkout_strategy = GIT_CHECKOUT_SAFE;
+        opts.checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
+        if ( !paths.isEmpty() )
+        {
+            // TODO: don't copy, just map paths here
+            result = git_strarray_copy( &opts.paths, Internal::StrArrayWrapper( paths ) );
+            if ( !result ) return;
+        }
         result = git_checkout_tree( d->repo()->mRepo, o, &opts );
         if (!result) return;
 

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -225,12 +225,20 @@ namespace Git
         }
         result = git_checkout_tree( d->repo()->mRepo, o, &opts );
 
-        if ( result && updateHEAD )
+        if ( updateHEAD )
             this->updateHEAD(result);
     }
 
     void Reference::updateHEAD(Result &result) const
     {
+        if ( !result ) return;
+
+        if ( !isValid() )
+        {
+            result.setInvalidObject();
+            return;
+        }
+
         if( git_reference_is_branch(d->mRef) )
         {
             // reference is a local branch

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -197,7 +197,8 @@ namespace Git
         return resolvedRef.objectId( result );
     }
 
-    void Reference::checkout(Result &result, bool force, const QStringList &paths) const
+    void Reference::checkout(Result &result, bool force, bool updateHEAD,
+                             const QStringList &paths) const
     {
         if (  !result )
         {
@@ -223,8 +224,13 @@ namespace Git
             if ( !result ) return;
         }
         result = git_checkout_tree( d->repo()->mRepo, o, &opts );
-        if (!result) return;
 
+        if ( result && updateHEAD )
+            this->updateHEAD(result);
+    }
+
+    void Reference::updateHEAD(Result &result) const
+    {
         if( git_reference_is_branch(d->mRef) )
         {
             // reference is a local branch

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -197,4 +197,26 @@ namespace Git
         return resolvedRef.objectId( result );
     }
 
+    void Reference::checkout(Result &result) const
+    {
+        if (  !result )
+        {
+            return;
+        }
+
+        if( !d )
+        {
+            result.setInvalidObject();
+            return;
+        }
+
+        git_object *o = NULL;
+        result = git_reference_peel( &o, d->mRef, GIT_OBJ_TREE );
+        if ( !result )
+            return;
+
+        git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+        result = git_checkout_tree( d->repo()->mRepo, o, &opts );
+    }
+
 }

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -212,11 +212,25 @@ namespace Git
 
         git_object *o = NULL;
         result = git_reference_peel( &o, d->mRef, GIT_OBJ_TREE );
-        if ( !result )
-            return;
+        if ( !result ) return;
 
         git_checkout_opts opts = GIT_CHECKOUT_OPTS_INIT;
+        opts.checkout_strategy = GIT_CHECKOUT_SAFE;
         result = git_checkout_tree( d->repo()->mRepo, o, &opts );
+        if (!result) return;
+
+        if( git_reference_is_branch(d->mRef) )
+        {
+            // reference is a local branch
+            result = git_repository_set_head(d->repo()->mRepo
+                                             , git_reference_name(d->mRef) );
+        }
+        else
+        {
+            // reference is detached
+            result = git_repository_set_head_detached( d->repo()->mRepo
+                                                       , git_reference_target(d->mRef) );
+        }
     }
 
 }

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -63,6 +63,8 @@ namespace Git
         Reference resolved( Result& result GITWRAP_DEFAULT_TLSRESULT );
         ObjectId resolveToObjectId( Result& result GITWRAP_DEFAULT_TLSRESULT );
 
+        void checkout( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+
     private:
         Internal::GitPtr< Internal::ReferencePrivate > d;
     };

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -67,7 +67,10 @@ namespace Git
 
         void checkout( Result& result,
                        bool force = false,
+                       bool updateHEAD = true,
                        const QStringList &paths = QStringList() ) const;
+
+        void updateHEAD(Result &result) const;
 
     private:
         Internal::GitPtr< Internal::ReferencePrivate > d;

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -19,6 +19,8 @@
 
 #include "GitWrap.hpp"
 
+#include <QStringList>
+
 namespace Git
 {
 
@@ -63,7 +65,9 @@ namespace Git
         Reference resolved( Result& result GITWRAP_DEFAULT_TLSRESULT );
         ObjectId resolveToObjectId( Result& result GITWRAP_DEFAULT_TLSRESULT );
 
-        void checkout( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        void checkout( Result& result GITWRAP_DEFAULT_TLSRESULT,
+                       bool force = false,
+                       const QStringList &paths = QStringList() ) const;
 
     private:
         Internal::GitPtr< Internal::ReferencePrivate > d;

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -65,7 +65,7 @@ namespace Git
         Reference resolved( Result& result GITWRAP_DEFAULT_TLSRESULT );
         ObjectId resolveToObjectId( Result& result GITWRAP_DEFAULT_TLSRESULT );
 
-        void checkout( Result& result GITWRAP_DEFAULT_TLSRESULT,
+        void checkout( Result& result,
                        bool force = false,
                        const QStringList &paths = QStringList() ) const;
 


### PR DESCRIPTION
TODO's:
- [x] Checkout a commit; equivalent to `git checkout <ref_or_sha1>`
- [x] Checkout files to index (discard unstaged changes)
- [x] Checkout files to specific revision; equivalent to: `git checkout <ref_or_sha1> -- file.txt`
