### PR TITLE
Refacture: result as first param

### DIFF
--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -225,7 +225,7 @@ namespace Git
         return Repository( d->repo() );
     }
 
-    bool DiffList::mergeOnto( DiffList onto, Result& result ) const
+    bool DiffList::mergeOnto(Result& result, DiffList onto) const
     {
         if( !result )
         {
@@ -242,7 +242,7 @@ namespace Git
         return result;
     }
 
-    bool DiffList::consumePatch( PatchConsumer* consumer, Result& result ) const
+    bool DiffList::consumePatch(Result& result, PatchConsumer* consumer) const
     {
         if( !result )
         {
@@ -270,7 +270,7 @@ namespace Git
         return result;
     }
 
-    bool DiffList::consumeChangeList( ChangeListConsumer* consumer, Result& result ) const
+    bool DiffList::consumeChangeList(Result& result, ChangeListConsumer* consumer) const
     {
         if( !result )
         {

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -301,7 +301,7 @@ namespace Git
     ChangeList DiffList::changeList(Result &result) const
     {
         Internal::DiffListConsumer consumer;
-        consumeChangeList(&consumer, result);
+        consumeChangeList(result, &consumer);
 
         return consumer.changeList();
     }

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -56,11 +56,11 @@ namespace Git
         bool isValid() const;
         Repository repository( Result& result ) const;
 
-        bool mergeOnto( DiffList other, Result& result ) const;
+        bool mergeOnto( Result& result, DiffList other ) const;
 
-        bool consumePatch( PatchConsumer* consumer, Result& result ) const;
-        bool consumeChangeList( ChangeListConsumer* consumer,
-                                Result& result ) const;
+        bool consumePatch( Result& result, PatchConsumer* consumer ) const;
+        bool consumeChangeList( Result& result,
+                                ChangeListConsumer* consumer ) const;
 
         ChangeList changeList(Result& result) const;
 

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -54,13 +54,13 @@ namespace Git
 
     public:
         bool isValid() const;
-        Repository repository( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        Repository repository( Result& result ) const;
 
-        bool mergeOnto( DiffList other, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool mergeOnto( DiffList other, Result& result ) const;
 
-        bool consumePatch( PatchConsumer* consumer, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool consumePatch( PatchConsumer* consumer, Result& result ) const;
         bool consumeChangeList( ChangeListConsumer* consumer,
-                                Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+                                Result& result ) const;
 
         ChangeList changeList(Result& result) const;
 

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -32,8 +32,6 @@
 #	define GITWRAP_API Q_DECL_IMPORT
 #endif
 
-#define GITWRAP_DEFAULT_TLSRESULT /* Nothing */
-
 namespace Git
 {
 

--- a/libGitWrap/GitWrapPrivate.hpp
+++ b/libGitWrap/GitWrapPrivate.hpp
@@ -147,7 +147,7 @@ namespace Git
 
         // Some internal helpers
         Signature git2Signature( const git_signature* gitsig );
-        git_signature* signature2git( const Signature& sig, Result& result );
+        git_signature* signature2git( Result& result, const Signature& sig );
         RefSpec mkRefSpec( const git_refspec* refspec );
         QStringList slFromStrArray( git_strarray* arry );
 

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -88,7 +88,7 @@ namespace Git
      * and can be stored back there. It is _not_ associated with any repository.
      *
      */
-    Index::Index( const QString& path, Result& result )
+    Index::Index(Result& result, const QString& path)
     {
         if( !result )
         {
@@ -164,7 +164,7 @@ namespace Git
         return Repository( d->repo() );
     }
 
-    IndexEntry Index::getEntry(int n, Result &result) const
+    IndexEntry Index::getEntry(Result &result, int n) const
     {
         if( !result )
         {
@@ -186,7 +186,7 @@ namespace Git
         return IndexEntry( new Internal::IndexEntryPrivate( entry ) );
     }
 
-    IndexEntry Index::getEntry(const QString &path, Result &result) const
+    IndexEntry Index::getEntry(Result &result, const QString &path) const
     {
         if( !result )
         {
@@ -216,7 +216,7 @@ namespace Git
      * @param[in]       path the file path
      * @param[in,out]   result the error result
      */
-    void Index::addEntry(const QString &path, Result &result)
+    void Index::addEntry(Result &result, const QString &path)
     {
         if ( !result )
             return;
@@ -238,7 +238,7 @@ namespace Git
      * @param[in]       path the file path
      * @param[in,out]   result the error result
      */
-    void Index::removeEntry(const QString &path, Result &result)
+    void Index::removeEntry(Result &result, const QString &path)
     {
         if ( !result )
             return;

--- a/libGitWrap/Index.hpp
+++ b/libGitWrap/Index.hpp
@@ -44,7 +44,7 @@ namespace Git
 
     public:
         Index( bool create = false );
-        Index( const QString& path, Result& result );
+        Index( Result& result, const QString& path );
         Index( const Index& other );
         ~Index();
 
@@ -60,11 +60,11 @@ namespace Git
         int count( Result& result ) const;
         Repository repository( Result& result ) const;
 
-        IndexEntry getEntry(int n, Result &result) const;
-        IndexEntry getEntry(const QString &path, Result &result) const;
+        IndexEntry getEntry(Result &result, int n) const;
+        IndexEntry getEntry(Result &result, const QString &path) const;
 
-        void addEntry(const QString &path, Result &result);
-        void removeEntry(const QString &path, Result &result);
+        void addEntry(Result &result, const QString &path);
+        void removeEntry(Result &result, const QString &path);
 
     private:
         Internal::GitPtr< Internal::IndexPrivate > d;

--- a/libGitWrap/Index.hpp
+++ b/libGitWrap/Index.hpp
@@ -54,17 +54,17 @@ namespace Git
     public:
         bool isValid() const;
 
-        void read( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void write( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        void read( Result& result );
+        void write( Result& result );
 
-        int count( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        Repository repository( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        int count( Result& result ) const;
+        Repository repository( Result& result ) const;
 
-        IndexEntry getEntry(int n, Result &result GITWRAP_DEFAULT_TLSRESULT) const;
-        IndexEntry getEntry(const QString &path, Result &result GITWRAP_DEFAULT_TLSRESULT) const;
+        IndexEntry getEntry(int n, Result &result) const;
+        IndexEntry getEntry(const QString &path, Result &result) const;
 
-        void addEntry(const QString &path, Result &result GITWRAP_DEFAULT_TLSRESULT);
-        void removeEntry(const QString &path, Result &result GITWRAP_DEFAULT_TLSRESULT);
+        void addEntry(const QString &path, Result &result);
+        void removeEntry(const QString &path, Result &result);
 
     private:
         Internal::GitPtr< Internal::IndexPrivate > d;

--- a/libGitWrap/Object.hpp
+++ b/libGitWrap/Object.hpp
@@ -65,12 +65,12 @@ namespace Git
         /**
          * @return the object's type
          */
-        ObjectType type( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        ObjectType type( Result& result ) const;
 
         /**
          * @return the object's id (OID)
          */
-        ObjectId id( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        ObjectId id( Result& result ) const;
 
         /**
          * @brief Converts a generic object into a Git tree object.
@@ -79,7 +79,7 @@ namespace Git
          *
          * @see isValid()
          */
-        ObjectTree asTree( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectTree asTree( Result& result );
 
         /**
          * @brief Converts a generic object into a Git commit object.
@@ -88,7 +88,7 @@ namespace Git
          *
          * @see isValid()
          */
-        ObjectCommit asCommit( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectCommit asCommit( Result& result );
 
         /**
          * @brief Converts a generic object into a Git BLOB object.
@@ -97,7 +97,7 @@ namespace Git
          *
          * @see isValid()
          */
-        ObjectBlob asBlob( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectBlob asBlob( Result& result );
 
         /**
          * @brief Converts a generic object into a Git tag object.
@@ -106,36 +106,36 @@ namespace Git
          *
          * @see isValid()
          */
-        ObjectTag asTag( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectTag asTag( Result& result );
 
         /**
          * @brief Checks, if this is a ObjectTree object.
          * @return true or false
          */
-        bool isTree( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool isTree( Result& result ) const;
 
         /**
          * @brief Checks, if this is a ObjectTree object.
          * @return true or false
          */
-        bool isTag( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool isTag( Result& result ) const;
 
         /**
          * @brief Checks, if this is a ObjectTree object.
          * @return true or false
          */
-        bool isCommit( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool isCommit( Result& result ) const;
 
         /**
          * @brief Checks, if this is a ObjectTree object.
          * @return true or false
          */
-        bool isBlob( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool isBlob( Result& result ) const;
 
         /**
          * @return the owner repository or an invalid repository
          */
-        Repository repository( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        Repository repository( Result& result ) const;
 
     protected:
         Internal::GitPtr< Internal::ObjectPrivate > d;

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -210,7 +210,7 @@ namespace Git
 
         for( int i = 0; result && i < parents.count(); i++ )
         {
-            if( isEqual( parents[ i ], result ) )
+            if( isEqual( result, parents[ i ] ) )
                 return true;
         }
 
@@ -223,7 +223,7 @@ namespace Git
 
         for( int i = 0; result && i < children.count(); i++ )
         {
-            if( parent.isEqual( children[ i ], result ) )
+            if( parent.isEqual( result, children[ i ] ) )
             {
                 return true;
             }
@@ -359,10 +359,10 @@ namespace Git
             return DiffList();
         }
 
-        ObjectCommit parentObjCommit = parentCommit( index, result );
+        ObjectCommit parentObjCommit = parentCommit( result, index );
         ObjectTree parentObjTree = parentObjCommit.tree( result );
 
-        return parentObjTree.diffToTree( tree( result ), result );
+        return parentObjTree.diffToTree( result, tree( result ) );
     }
 
     DiffList ObjectCommit::diffFromAllParents( Result& result )
@@ -383,11 +383,11 @@ namespace Git
             return DiffList();
         }
 
-        DiffList dl = diffFromParent( 0, result );
+        DiffList dl = diffFromParent( result, 0 );
         for( unsigned int i = 1; i < numParentCommits(); i++ )
         {
-            DiffList dl2 = diffFromParent( i, result );
-            dl2.mergeOnto( dl, result );
+            DiffList dl2 = diffFromParent( result, i );
+            dl2.mergeOnto( result, dl );
         }
 
         return dl;

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -111,7 +111,7 @@ namespace Git
         return ids;
     }
 
-    ObjectCommit ObjectCommit::parentCommit( unsigned int index, Result& result ) const
+    ObjectCommit ObjectCommit::parentCommit(Result& result, unsigned int index) const
     {
         if( !result )
         {
@@ -135,7 +135,7 @@ namespace Git
         return new Internal::ObjectPrivate( d->repo(), (git_object*) gitparent );
     }
 
-    ObjectId ObjectCommit::parentCommitId( unsigned int index, Result& result ) const
+    ObjectId ObjectCommit::parentCommitId(Result& result, unsigned int index) const
     {
         if( !result )
         {
@@ -204,7 +204,7 @@ namespace Git
         return git_commit_parentcount( commit );
     }
 
-    bool ObjectCommit::isParentOf( const Git::ObjectCommit& child, Result& result ) const
+    bool ObjectCommit::isParentOf(Result& result, const Git::ObjectCommit& child) const
     {
         QList< Git::ObjectCommit > parents = child.parentCommits( result );
 
@@ -217,7 +217,7 @@ namespace Git
         return false;
     }
 
-    bool ObjectCommit::isChildOf( const Git::ObjectCommit& parent, Result& result ) const
+    bool ObjectCommit::isChildOf(Result& result, const Git::ObjectCommit& parent) const
     {
         QList< Git::ObjectCommit > children = parentCommits( result );
 
@@ -232,7 +232,7 @@ namespace Git
         return false;
     }
 
-    bool ObjectCommit::isEqual( const Git::ObjectCommit& commit, Result& result ) const
+    bool ObjectCommit::isEqual(Result& result, const Git::ObjectCommit& commit) const
     {
         return id( result ) == commit.id( result ) && result;
     }
@@ -346,7 +346,7 @@ namespace Git
         return Reference( new Internal::ReferencePrivate( d->repo(), ref ) );
     }
 
-    DiffList ObjectCommit::diffFromParent( unsigned int index, Result& result )
+    DiffList ObjectCommit::diffFromParent(Result& result, unsigned int index)
     {
         if( !result )
         {

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -64,13 +64,13 @@ namespace Git
 
         ObjectIdList parentCommitIds( Result& result ) const;
         QList< ObjectCommit > parentCommits( Result& result ) const;
-        ObjectCommit parentCommit( unsigned int index, Result& result ) const;
-        ObjectId parentCommitId( unsigned int index, Result& result ) const;
+        ObjectCommit parentCommit( Result& result, unsigned int index ) const;
+        ObjectId parentCommitId( Result& result, unsigned int index ) const;
         unsigned int numParentCommits() const;
 
-        bool isParentOf( const Git::ObjectCommit& child, Result& result ) const;
-        bool isChildOf( const Git::ObjectCommit& parent, Result& result ) const;
-        bool isEqual( const Git::ObjectCommit& commit, Result& result ) const;
+        bool isParentOf( Result& result, const Git::ObjectCommit& child ) const;
+        bool isChildOf( Result& result, const Git::ObjectCommit& parent ) const;
+        bool isEqual( Result& result, const Git::ObjectCommit& commit ) const;
 
         Signature author( Result& result ) const;
         Signature committer( Result& result ) const;
@@ -81,7 +81,7 @@ namespace Git
         Reference createBranch( const QString& name, bool force,
                                 Result& result ) const;
 
-        DiffList diffFromParent( unsigned int index, Result& result );
+        DiffList diffFromParent( Result& result, unsigned int index );
         DiffList diffFromAllParents( Result& result );
     };
 

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -59,30 +59,30 @@ namespace Git
         }
 
     public:
-        ObjectTree tree( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectId treeId( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectTree tree( Result& result );
+        ObjectId treeId( Result& result );
 
-        ObjectIdList parentCommitIds( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        QList< ObjectCommit > parentCommits( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        ObjectCommit parentCommit( unsigned int index, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        ObjectId parentCommitId( unsigned int index, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        ObjectIdList parentCommitIds( Result& result ) const;
+        QList< ObjectCommit > parentCommits( Result& result ) const;
+        ObjectCommit parentCommit( unsigned int index, Result& result ) const;
+        ObjectId parentCommitId( unsigned int index, Result& result ) const;
         unsigned int numParentCommits() const;
 
-        bool isParentOf( const Git::ObjectCommit& child, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        bool isChildOf( const Git::ObjectCommit& parent, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        bool isEqual( const Git::ObjectCommit& commit, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool isParentOf( const Git::ObjectCommit& child, Result& result ) const;
+        bool isChildOf( const Git::ObjectCommit& parent, Result& result ) const;
+        bool isEqual( const Git::ObjectCommit& commit, Result& result ) const;
 
-        Signature author( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        Signature committer( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        Signature author( Result& result ) const;
+        Signature committer( Result& result ) const;
 
-        QString message( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        QString shortMessage( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        QString message( Result& result ) const;
+        QString shortMessage( Result& result ) const;
 
         Reference createBranch( const QString& name, bool force,
-                                Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+                                Result& result ) const;
 
-        DiffList diffFromParent( unsigned int index, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        DiffList diffFromAllParents( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        DiffList diffFromParent( unsigned int index, Result& result );
+        DiffList diffFromAllParents( Result& result );
     };
 
     /**

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -49,13 +49,13 @@ namespace Git
         bool operator==( const Git::ObjectCommit& commit ) const
         {
             Result r;
-            return isEqual( commit, r ) && r;
+            return isEqual( r, commit ) && r;
         }
 
         bool operator!=( const Git::ObjectCommit& commit ) const
         {
             Result r;
-            return !isEqual( commit, r ) && r;
+            return !isEqual( r, commit ) && r;
         }
 
     public:

--- a/libGitWrap/ObjectTree.cpp
+++ b/libGitWrap/ObjectTree.cpp
@@ -45,7 +45,7 @@ namespace Git
     {
     }
 
-    ObjectTree ObjectTree::subPath( const QString& pathName, Result& result ) const
+    ObjectTree ObjectTree::subPath(Result& result , const QString& pathName) const
     {
         if( !result )
         {
@@ -82,7 +82,7 @@ namespace Git
         return new Internal::ObjectPrivate( d->repo(), subObject );
     }
 
-    DiffList ObjectTree::diffToTree( ObjectTree newTree, Result& result )
+    DiffList ObjectTree::diffToTree(Result& result , ObjectTree newTree)
     {
         if( !result )
         {

--- a/libGitWrap/ObjectTree.hpp
+++ b/libGitWrap/ObjectTree.hpp
@@ -40,11 +40,11 @@ namespace Git
         ObjectTree( const ObjectTree& o );
 
     public:
-        ObjectTree subPath( const QString& pathName, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        ObjectTree subPath( const QString& pathName, Result& result ) const;
 
-        DiffList diffToTree( ObjectTree newTree, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        DiffList diffToIndex( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        DiffList diffToWorkingDir( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        DiffList diffToTree( ObjectTree newTree, Result& result );
+        DiffList diffToIndex( Result& result );
+        DiffList diffToWorkingDir( Result& result );
 
         size_t entryCount() const;
         TreeEntry entryAt( size_t index ) const;

--- a/libGitWrap/ObjectTree.hpp
+++ b/libGitWrap/ObjectTree.hpp
@@ -40,9 +40,9 @@ namespace Git
         ObjectTree( const ObjectTree& o );
 
     public:
-        ObjectTree subPath( const QString& pathName, Result& result ) const;
+        ObjectTree subPath( Result& result, const QString& pathName ) const;
 
-        DiffList diffToTree( ObjectTree newTree, Result& result );
+        DiffList diffToTree( Result& result, ObjectTree newTree );
         DiffList diffToIndex( Result& result );
         DiffList diffToWorkingDir( Result& result );
 

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -52,16 +52,16 @@ namespace Git
 
     public:
         bool isValid() const;
-        bool destroy( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        bool destroy( Result& result );
         QString name() const;
 
-        Type type( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        ObjectId objectId( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        QString target( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        Type type( Result& result ) const;
+        ObjectId objectId( Result& result ) const;
+        QString target( Result& result ) const;
 
-        Repository repository( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        Reference resolved( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectId resolveToObjectId( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        Repository repository( Result& result ) const;
+        Reference resolved( Result& result );
+        ObjectId resolveToObjectId( Result& result );
 
     private:
         Internal::GitPtr< Internal::ReferencePrivate > d;

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -106,7 +106,7 @@ namespace Git
         return QString::fromUtf8( git_remote_url( d->mRemote ) );
     }
 
-    bool Remote::setFetchSpec( const QString& spec, Result& result )
+    bool Remote::setFetchSpec(Result& result, const QString& spec)
     {
         if( !result )
         {
@@ -122,7 +122,7 @@ namespace Git
         return result;
     }
 
-    bool Remote::setPushSpec( const QString& spec, Result& result )
+    bool Remote::setPushSpec(Result& result, const QString& spec)
     {
         if( !result )
         {
@@ -171,7 +171,7 @@ namespace Git
     }
 
 
-    bool Remote::connect( bool forFetch, Result& result )
+    bool Remote::connect(Result& result, bool forFetch)
     {
         if( !result )
         {

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -51,13 +51,13 @@ namespace Git
     public:
         bool isValid() const;
 
-        bool save( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        bool save( Result& result );
 
         QString name() const;
         QString url() const;
 
-        bool setFetchSpec( const QString& spec, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        bool setPushSpec( const QString& spec, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        bool setFetchSpec( const QString& spec, Result& result );
+        bool setPushSpec( const QString& spec, Result& result );
 
         RefSpec fetchSpec() const;
         RefSpec pushSpec() const;
@@ -65,10 +65,10 @@ namespace Git
         static bool isValidUrl( const QString& url );
         static bool isSupportedUrl( const QString& url );
 
-        bool connect( bool forFetch, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void disconnect( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        bool download( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        bool updateTips( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        bool connect( bool forFetch, Result& result );
+        void disconnect( Result& result );
+        bool download( Result& result );
+        bool updateTips( Result& result );
 
     private:
         Internal::GitPtr< Internal::RemotePrivate > d;

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -56,8 +56,8 @@ namespace Git
         QString name() const;
         QString url() const;
 
-        bool setFetchSpec( const QString& spec, Result& result );
-        bool setPushSpec( const QString& spec, Result& result );
+        bool setFetchSpec( Result& result, const QString& spec );
+        bool setPushSpec( Result& result, const QString& spec );
 
         RefSpec fetchSpec() const;
         RefSpec pushSpec() const;
@@ -65,7 +65,7 @@ namespace Git
         static bool isValidUrl( const QString& url );
         static bool isSupportedUrl( const QString& url );
 
-        bool connect( bool forFetch, Result& result );
+        bool connect( Result& result, bool forFetch );
         void disconnect( Result& result );
         bool download( Result& result );
         bool updateTips( Result& result );

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -488,7 +488,7 @@ namespace Git
 
     QStringList Repository::allBranches( Result& result )
     {
-        return branches( true, true, result );
+        return branches( result, true, true );
     }
 
     QString Repository::currentBranch( Result& result )
@@ -700,7 +700,7 @@ namespace Git
         return new Internal::ReferencePrivate( d, refHead );
     }
 
-    Object Repository::lookup( const ObjectId& id, ObjectType ot, Result& result )
+    Object Repository::lookup( Result& result, const ObjectId& id, ObjectType ot )
     {
         if( !result )
         {
@@ -737,47 +737,47 @@ namespace Git
 
     ObjectCommit Repository::lookupCommit(Result& result, const ObjectId& id)
     {
-        return lookup( id, otCommit, result ).asCommit( result );
+        return lookup( result, id, otCommit ).asCommit( result );
     }
 
     ObjectTree Repository::lookupTree(Result& result, const ObjectId& id)
     {
-        return lookup( id, otTree, result ).asTree( result );
+        return lookup( result, id, otTree ).asTree( result );
     }
 
     ObjectBlob Repository::lookupBlob(Result& result, const ObjectId& id)
     {
-        return lookup( id, otBlob, result ).asBlob( result );
+        return lookup( result, id, otBlob ).asBlob( result );
     }
 
     ObjectTag Repository::lookupTag(Result& result, const ObjectId& id)
     {
-        return lookup( id, otTag, result ).asTag( result );
+        return lookup( result, id, otTag ).asTag( result );
     }
 
-    Object Repository::lookup( const QString& refName, ObjectType ot, Result& result )
+    Object Repository::lookup( Result& result, const QString& refName, ObjectType ot )
     {
-        return lookup( lookupRef( refName, result ).resolveToObjectId( result ), ot, result );
+        return lookup( result, lookupRef( result, refName ).resolveToObjectId( result ), ot );
     }
 
     ObjectCommit Repository::lookupCommit(Result& result, const QString& refName)
     {
-        return lookupCommit( lookupRef( refName, result ).resolveToObjectId( result ), result );
+        return lookupCommit( result, lookupRef( result, refName ).resolveToObjectId( result ) );
     }
 
     ObjectTree Repository::lookupTree(Result& result, const QString& refName)
     {
-        return lookupTree( lookupRef( refName, result ).resolveToObjectId( result ), result );
+        return lookupTree( result, lookupRef( result, refName ).resolveToObjectId( result ) );
     }
 
     ObjectBlob Repository::lookupBlob(Result& result, const QString& refName)
     {
-        return lookupBlob( lookupRef( refName, result ).resolveToObjectId( result ), result );
+        return lookupBlob( result, lookupRef( result, refName ).resolveToObjectId( result ) );
     }
 
     ObjectTag Repository::lookupTag(Result& result, const QString& refName)
     {
-        return lookupTag( lookupRef( refName, result ).resolveToObjectId( result ), result );
+        return lookupTag( result, lookupRef( result, refName ).resolveToObjectId( result ) );
     }
 
     RevisionWalker Repository::newWalker( Result& result )
@@ -901,7 +901,7 @@ namespace Git
 
         if( !fetchSpec.isEmpty() )
         {
-            remo.setFetchSpec( fetchSpec, result );
+            remo.setFetchSpec( result, fetchSpec );
             if( !result )
             {
                 return Remote();
@@ -911,16 +911,15 @@ namespace Git
         return remo;
     }
 
-    DiffList Repository::diffCommitToCommit( ObjectCommit oldCommit, ObjectCommit newCommit,
-                                             Result& result )
+    DiffList Repository::diffCommitToCommit( Result& result, ObjectCommit oldCommit,
+                                             ObjectCommit newCommit )
     {
-        return diffTreeToTree( oldCommit.tree( result ), newCommit.tree( result ), result );
+        return diffTreeToTree( result, oldCommit.tree( result ), newCommit.tree( result ) );
     }
 
-    DiffList Repository::diffTreeToTree( ObjectTree oldTree, ObjectTree newTree,
-                                         Result& result  )
+    DiffList Repository::diffTreeToTree(Result& result, ObjectTree oldTree, ObjectTree newTree)
     {
-        return oldTree.diffToTree( newTree, result );
+        return oldTree.diffToTree( result, newTree );
     }
 
     DiffList Repository::diffIndexToTree(Result& result, ObjectTree oldTree)

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -338,7 +338,7 @@ namespace Git
      * @param r the error result
      * @return the current file status
      */
-    Git::StatusFlags Repository::status(const QString &fileName, Result &result) const
+    Git::StatusFlags Repository::status(Result &result, const QString &fileName) const
     {
         unsigned int status = GIT_STATUS_CURRENT;
 
@@ -536,7 +536,7 @@ namespace Git
 
     }
 
-    QStringList Repository::branches( bool local, bool remote, Result& result )
+    QStringList Repository::branches(Result& result, bool local, bool remote)
     {
         if( !result )
         {
@@ -735,22 +735,22 @@ namespace Git
         return new Internal::ObjectPrivate( d, obj );
     }
 
-    ObjectCommit Repository::lookupCommit( const ObjectId& id, Result& result )
+    ObjectCommit Repository::lookupCommit(Result& result, const ObjectId& id)
     {
         return lookup( id, otCommit, result ).asCommit( result );
     }
 
-    ObjectTree Repository::lookupTree( const ObjectId& id, Result& result )
+    ObjectTree Repository::lookupTree(Result& result, const ObjectId& id)
     {
         return lookup( id, otTree, result ).asTree( result );
     }
 
-    ObjectBlob Repository::lookupBlob( const ObjectId& id, Result& result )
+    ObjectBlob Repository::lookupBlob(Result& result, const ObjectId& id)
     {
         return lookup( id, otBlob, result ).asBlob( result );
     }
 
-    ObjectTag Repository::lookupTag( const ObjectId& id, Result& result )
+    ObjectTag Repository::lookupTag(Result& result, const ObjectId& id)
     {
         return lookup( id, otTag, result ).asTag( result );
     }
@@ -760,22 +760,22 @@ namespace Git
         return lookup( lookupRef( refName, result ).resolveToObjectId( result ), ot, result );
     }
 
-    ObjectCommit Repository::lookupCommit( const QString& refName, Result& result )
+    ObjectCommit Repository::lookupCommit(Result& result, const QString& refName)
     {
         return lookupCommit( lookupRef( refName, result ).resolveToObjectId( result ), result );
     }
 
-    ObjectTree Repository::lookupTree( const QString& refName, Result& result )
+    ObjectTree Repository::lookupTree(Result& result, const QString& refName)
     {
         return lookupTree( lookupRef( refName, result ).resolveToObjectId( result ), result );
     }
 
-    ObjectBlob Repository::lookupBlob( const QString& refName, Result& result )
+    ObjectBlob Repository::lookupBlob(Result& result, const QString& refName)
     {
         return lookupBlob( lookupRef( refName, result ).resolveToObjectId( result ), result );
     }
 
-    ObjectTag Repository::lookupTag( const QString& refName, Result& result )
+    ObjectTag Repository::lookupTag(Result& result, const QString& refName)
     {
         return lookupTag( lookupRef( refName, result ).resolveToObjectId( result ), result );
     }
@@ -804,7 +804,7 @@ namespace Git
         return new Internal::RevisionWalkerPrivate( d, walker );
     }
 
-    bool Repository::shouldIgnore( const QString& filePath, Result& result ) const
+    bool Repository::shouldIgnore(Result& result, const QString& filePath) const
     {
         if( !result )
         {
@@ -851,7 +851,7 @@ namespace Git
         return Internal::slFromStrArray( &arr );
     }
 
-    Remote Repository::remote( const QString& remoteName, Result& result ) const
+    Remote Repository::remote(Result& result, const QString& remoteName) const
     {
         if( !result )
         {
@@ -875,8 +875,8 @@ namespace Git
         return new Internal::RemotePrivate( const_cast< Internal::RepositoryPrivate* >( *d ), remote );
     }
 
-    Remote Repository::createRemote( const QString& remoteName, const QString& url,
-                                     const QString& fetchSpec, Result& result )
+    Remote Repository::createRemote(Result& result, const QString& remoteName, const QString& url,
+                                     const QString& fetchSpec)
     {
         if( !result )
         {
@@ -923,12 +923,12 @@ namespace Git
         return oldTree.diffToTree( newTree, result );
     }
 
-    DiffList Repository::diffIndexToTree( ObjectTree oldTree, Result& result )
+    DiffList Repository::diffIndexToTree(Result& result, ObjectTree oldTree)
     {
         return oldTree.diffToIndex( result );
     }
 
-    DiffList Repository::diffTreeToWorkingDir( ObjectTree oldTree, Result& result )
+    DiffList Repository::diffTreeToWorkingDir(Result& result, ObjectTree oldTree)
     {
         return oldTree.diffToWorkingDir( result );
     }
@@ -1002,7 +1002,7 @@ namespace Git
         return list;
     }
 
-    Submodule Repository::submodule( const QString& name, Result& result  )
+    Submodule Repository::submodule(Result& result, const QString& name)
     {
         if( !result )
         {
@@ -1018,7 +1018,7 @@ namespace Git
         return Submodule( d, name );
     }
 
-    Reference Repository::lookupRef( const QString& refName, Result& result )
+    Reference Repository::lookupRef(Result& result, const QString& refName)
     {
         if( !result )
         {

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -101,16 +101,14 @@ namespace Git
         Reference lookupRef( Result& result, const QString& refName );
         ObjectId resolveRef( Result& result, const QString& refName );
 
-        Object lookup( const ObjectId& id, ObjectType ot /* = otAny */,
-                       Result& result );
+        Object lookup(Result& result, const ObjectId& id, ObjectType ot /* = otAny */);
 
         ObjectCommit lookupCommit( Result& result, const ObjectId& id );
         ObjectTree lookupTree( Result& result, const ObjectId& id );
         ObjectBlob lookupBlob( Result& result, const ObjectId& id );
         ObjectTag lookupTag( Result& result, const ObjectId& id );
 
-        Object lookup( const QString& refName, ObjectType ot /* = otAny */,
-                       Result& result );
+        Object lookup(Result& result, const QString& refName, ObjectType ot /* = otAny */);
 
         ObjectCommit lookupCommit( Result& result, const QString& refName );
         ObjectTree lookupTree( Result& result, const QString& refName );
@@ -126,11 +124,10 @@ namespace Git
         Remote createRemote( Result& result, const QString& remoteName, const QString& url,
                              const QString& fetchSpec );
 
-        DiffList diffCommitToCommit( ObjectCommit oldCommit, ObjectCommit newCommit,
-                                     Result& result );
+        DiffList diffCommitToCommit(Result& result, ObjectCommit oldCommit, ObjectCommit newCommit);
 
-        DiffList diffTreeToTree( ObjectTree oldTree, ObjectTree newTree,
-                                 Result& result);
+        DiffList diffTreeToTree( Result& result, ObjectTree oldTree,
+                                 ObjectTree newTree);
 
         DiffList diffIndexToTree( Result& result, ObjectTree oldTree );
 

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -63,15 +63,15 @@ namespace Git
     public:
         static Repository create( const QString& path,
                                   bool bare,
-                                  Result& result GITWRAP_DEFAULT_TLSRESULT );
+                                  Result& result );
 
         static QString discover( const QString& startPath,
                                  bool acrossFs /* = false */,
                                  const QStringList& ceilingDirs /* = QStringList() */,
-                                 Result& result GITWRAP_DEFAULT_TLSRESULT );
+                                 Result& result );
 
         static Repository open( const QString& path,
-                                Result& result GITWRAP_DEFAULT_TLSRESULT );
+                                Result& result );
 
         bool isValid() const;
         bool isBare() const;
@@ -81,64 +81,64 @@ namespace Git
 
         QString name() const;
 
-        QStringList allReferences( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        QStringList allBranches( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        QString currentBranch( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        QStringList branches( bool local, bool remote, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        QStringList allTags( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        QStringList allReferences( Result& result );
+        QStringList allBranches( Result& result );
+        QString currentBranch( Result& result );
+        QStringList branches( bool local, bool remote, Result& result );
+        QStringList allTags( Result& result );
 
-        ResolvedRefs allResolvedRefs( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ResolvedRefs allResolvedRefs( Result& result );
 
         bool renameBranch( const QString& oldName, const QString& newName, bool force /* = false */,
-                           Result& result GITWRAP_DEFAULT_TLSRESULT );
+                           Result& result );
 
-        Index index( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        Index index( Result& result );
 
-        Git::StatusFlags status(const QString &fileName, Result &result GITWRAP_DEFAULT_TLSRESULT) const;
-        Git::StatusHash status(Result &result GITWRAP_DEFAULT_TLSRESULT) const;
+        Git::StatusFlags status(const QString &fileName, Result &result) const;
+        Git::StatusHash status(Result &result) const;
 
-        Reference HEAD( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        Reference lookupRef( const QString& refName, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectId resolveRef( const QString& refName, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        Reference HEAD( Result& result ) const;
+        Reference lookupRef( const QString& refName, Result& result );
+        ObjectId resolveRef( const QString& refName, Result& result );
 
         Object lookup( const ObjectId& id, ObjectType ot /* = otAny */,
-                       Result& result GITWRAP_DEFAULT_TLSRESULT );
+                       Result& result );
 
-        ObjectCommit lookupCommit( const ObjectId& id, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectTree lookupTree( const ObjectId& id, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectBlob lookupBlob( const ObjectId& id, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectTag lookupTag( const ObjectId& id, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectCommit lookupCommit( const ObjectId& id, Result& result );
+        ObjectTree lookupTree( const ObjectId& id, Result& result );
+        ObjectBlob lookupBlob( const ObjectId& id, Result& result );
+        ObjectTag lookupTag( const ObjectId& id, Result& result );
 
         Object lookup( const QString& refName, ObjectType ot /* = otAny */,
-                       Result& result GITWRAP_DEFAULT_TLSRESULT );
+                       Result& result );
 
-        ObjectCommit lookupCommit( const QString& refName, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectTree lookupTree( const QString& refName, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectBlob lookupBlob( const QString& refName, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectTag lookupTag( const QString& refName, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        ObjectCommit lookupCommit( const QString& refName, Result& result );
+        ObjectTree lookupTree( const QString& refName, Result& result );
+        ObjectBlob lookupBlob( const QString& refName, Result& result );
+        ObjectTag lookupTag( const QString& refName, Result& result );
 
-        bool shouldIgnore( const QString& filePath, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        bool shouldIgnore( const QString& filePath, Result& result ) const;
 
-        RevisionWalker newWalker( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        RevisionWalker newWalker( Result& result );
 
-        QStringList allRemotes( Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
-        Remote remote( const QString& remoteName, Result& result GITWRAP_DEFAULT_TLSRESULT ) const;
+        QStringList allRemotes( Result& result ) const;
+        Remote remote( const QString& remoteName, Result& result ) const;
         Remote createRemote( const QString& remoteName, const QString& url,
-                             const QString& fetchSpec, Result& result GITWRAP_DEFAULT_TLSRESULT );
+                             const QString& fetchSpec, Result& result );
 
         DiffList diffCommitToCommit( ObjectCommit oldCommit, ObjectCommit newCommit,
-                                     Result& result GITWRAP_DEFAULT_TLSRESULT );
+                                     Result& result );
 
         DiffList diffTreeToTree( ObjectTree oldTree, ObjectTree newTree,
-                                 Result& result GITWRAP_DEFAULT_TLSRESULT);
+                                 Result& result);
 
-        DiffList diffIndexToTree( ObjectTree oldTree, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        DiffList diffIndexToTree( ObjectTree oldTree, Result& result );
 
-        DiffList diffTreeToWorkingDir( ObjectTree oldTree, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        DiffList diffIndexToWorkingDir( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        DiffList diffTreeToWorkingDir( ObjectTree oldTree, Result& result );
+        DiffList diffIndexToWorkingDir( Result& result );
 
-        SubmoduleList submodules( Result& result GITWRAP_DEFAULT_TLSRESULT );
-        Submodule submodule( const QString& name, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        SubmoduleList submodules( Result& result );
+        Submodule submodule( const QString& name, Result& result );
 
     private:
         Internal::GitPtr< Internal::RepositoryPrivate > d;

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -84,7 +84,7 @@ namespace Git
         QStringList allReferences( Result& result );
         QStringList allBranches( Result& result );
         QString currentBranch( Result& result );
-        QStringList branches( bool local, bool remote, Result& result );
+        QStringList branches( Result& result, bool local, bool remote );
         QStringList allTags( Result& result );
 
         ResolvedRefs allResolvedRefs( Result& result );
@@ -94,37 +94,37 @@ namespace Git
 
         Index index( Result& result );
 
-        Git::StatusFlags status(const QString &fileName, Result &result) const;
+        Git::StatusFlags status(Result &result, const QString &fileName) const;
         Git::StatusHash status(Result &result) const;
 
         Reference HEAD( Result& result ) const;
-        Reference lookupRef( const QString& refName, Result& result );
-        ObjectId resolveRef( const QString& refName, Result& result );
+        Reference lookupRef( Result& result, const QString& refName );
+        ObjectId resolveRef( Result& result, const QString& refName );
 
         Object lookup( const ObjectId& id, ObjectType ot /* = otAny */,
                        Result& result );
 
-        ObjectCommit lookupCommit( const ObjectId& id, Result& result );
-        ObjectTree lookupTree( const ObjectId& id, Result& result );
-        ObjectBlob lookupBlob( const ObjectId& id, Result& result );
-        ObjectTag lookupTag( const ObjectId& id, Result& result );
+        ObjectCommit lookupCommit( Result& result, const ObjectId& id );
+        ObjectTree lookupTree( Result& result, const ObjectId& id );
+        ObjectBlob lookupBlob( Result& result, const ObjectId& id );
+        ObjectTag lookupTag( Result& result, const ObjectId& id );
 
         Object lookup( const QString& refName, ObjectType ot /* = otAny */,
                        Result& result );
 
-        ObjectCommit lookupCommit( const QString& refName, Result& result );
-        ObjectTree lookupTree( const QString& refName, Result& result );
-        ObjectBlob lookupBlob( const QString& refName, Result& result );
-        ObjectTag lookupTag( const QString& refName, Result& result );
+        ObjectCommit lookupCommit( Result& result, const QString& refName );
+        ObjectTree lookupTree( Result& result, const QString& refName );
+        ObjectBlob lookupBlob( Result& result, const QString& refName );
+        ObjectTag lookupTag( Result& result, const QString& refName );
 
-        bool shouldIgnore( const QString& filePath, Result& result ) const;
+        bool shouldIgnore( Result& result, const QString& filePath ) const;
 
         RevisionWalker newWalker( Result& result );
 
         QStringList allRemotes( Result& result ) const;
-        Remote remote( const QString& remoteName, Result& result ) const;
-        Remote createRemote( const QString& remoteName, const QString& url,
-                             const QString& fetchSpec, Result& result );
+        Remote remote( Result& result, const QString& remoteName ) const;
+        Remote createRemote( Result& result, const QString& remoteName, const QString& url,
+                             const QString& fetchSpec );
 
         DiffList diffCommitToCommit( ObjectCommit oldCommit, ObjectCommit newCommit,
                                      Result& result );
@@ -132,13 +132,13 @@ namespace Git
         DiffList diffTreeToTree( ObjectTree oldTree, ObjectTree newTree,
                                  Result& result);
 
-        DiffList diffIndexToTree( ObjectTree oldTree, Result& result );
+        DiffList diffIndexToTree( Result& result, ObjectTree oldTree );
 
-        DiffList diffTreeToWorkingDir( ObjectTree oldTree, Result& result );
+        DiffList diffTreeToWorkingDir( Result& result, ObjectTree oldTree );
         DiffList diffIndexToWorkingDir( Result& result );
 
         SubmoduleList submodules( Result& result );
-        Submodule submodule( const QString& name, Result& result );
+        Submodule submodule( Result& result, const QString& name );
 
     private:
         Internal::GitPtr< Internal::RepositoryPrivate > d;

--- a/libGitWrap/RevisionWalker.cpp
+++ b/libGitWrap/RevisionWalker.cpp
@@ -110,7 +110,7 @@ namespace Git
             return;
         }
 
-        pushRef( ref.name(), result );
+        pushRef( result, ref.name() );
     }
 
     void RevisionWalker::pushRef(Result& result, const QString& name)
@@ -174,7 +174,7 @@ namespace Git
             return;
         }
 
-        hideRef( ref.name(), result );
+        hideRef( result, ref.name() );
     }
 
     void RevisionWalker::hideRef(Result& result, const QString& name)
@@ -253,7 +253,7 @@ namespace Git
         }
 
         ObjectId id;
-        while( next( id, result ) )
+        while( next( result, id ) )
         {
             if( !result )
             {

--- a/libGitWrap/RevisionWalker.cpp
+++ b/libGitWrap/RevisionWalker.cpp
@@ -80,7 +80,7 @@ namespace Git
         git_revwalk_reset( d->mWalker );
     }
 
-    void RevisionWalker::push( const ObjectId& id, Result& result )
+    void RevisionWalker::push(Result& result, const ObjectId& id)
     {
         if( !result )
         {
@@ -96,7 +96,7 @@ namespace Git
         result = git_revwalk_push( d->mWalker, (const git_oid*) id.raw() );
     }
 
-    void RevisionWalker::push( const Reference& ref, Result& result )
+    void RevisionWalker::push(Result& result, const Reference& ref)
     {
 
         if( !result )
@@ -113,7 +113,7 @@ namespace Git
         pushRef( ref.name(), result );
     }
 
-    void RevisionWalker::pushRef( const QString& name, Result& result )
+    void RevisionWalker::pushRef(Result& result, const QString& name)
     {
         if( !result )
         {
@@ -145,7 +145,7 @@ namespace Git
         result = git_revwalk_push_head( d->mWalker );
     }
 
-    void RevisionWalker::hide( const ObjectId& id, Result& result )
+    void RevisionWalker::hide( Result& result, const ObjectId& id )
     {
         if( !result )
         {
@@ -161,7 +161,7 @@ namespace Git
         result = git_revwalk_hide( d->mWalker, (const git_oid*) id.raw() );
     }
 
-    void RevisionWalker::hide( const Reference& ref, Result& result )
+    void RevisionWalker::hide(Result& result, const Reference& ref)
     {
         if( !result )
         {
@@ -177,7 +177,7 @@ namespace Git
         hideRef( ref.name(), result );
     }
 
-    void RevisionWalker::hideRef( const QString& name, Result& result )
+    void RevisionWalker::hideRef(Result& result, const QString& name)
     {
         if( !result )
         {
@@ -209,7 +209,7 @@ namespace Git
         result = git_revwalk_hide_head( d->mWalker );
     }
 
-    bool RevisionWalker::next( ObjectId& oidNext, Result& result )
+    bool RevisionWalker::next(Result& result, ObjectId& oidNext)
     {
         if( !result )
         {
@@ -265,7 +265,7 @@ namespace Git
         return ids;
     }
 
-    void RevisionWalker::setSorting( bool topological, bool timed, Result& result )
+    void RevisionWalker::setSorting(Result& result, bool topological, bool timed)
     {
         if( !result )
         {

--- a/libGitWrap/RevisionWalker.hpp
+++ b/libGitWrap/RevisionWalker.hpp
@@ -46,22 +46,22 @@ namespace Git
     public:
         bool isValid() const;
 
-        void reset( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        void reset( Result& result );
 
-        void push( const ObjectId& id, Result& result GITWRAP_DEFAULT_TLSRESULT  );
-        void push( const Reference& ref, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void pushRef( const QString& name, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void pushHead( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        void push( const ObjectId& id, Result& result  );
+        void push( const Reference& ref, Result& result );
+        void pushRef( const QString& name, Result& result );
+        void pushHead( Result& result );
 
-        void hide( const ObjectId& id, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void hide( const Reference& ref, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void hideRef( const QString& name, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        void hideHead( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        void hide( const ObjectId& id, Result& result );
+        void hide( const Reference& ref, Result& result );
+        void hideRef( const QString& name, Result& result );
+        void hideHead( Result& result );
 
-        bool next( ObjectId& oidNext, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        QVector< ObjectId > all( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        bool next( ObjectId& oidNext, Result& result );
+        QVector< ObjectId > all( Result& result );
 
-        void setSorting( bool topological, bool timed, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        void setSorting( bool topological, bool timed, Result& result );
 
     private:
         Internal::GitPtr< Internal::RevisionWalkerPrivate > d;

--- a/libGitWrap/RevisionWalker.hpp
+++ b/libGitWrap/RevisionWalker.hpp
@@ -48,20 +48,20 @@ namespace Git
 
         void reset( Result& result );
 
-        void push( const ObjectId& id, Result& result  );
-        void push( const Reference& ref, Result& result );
-        void pushRef( const QString& name, Result& result );
+        void push( Result& result, const ObjectId& id  );
+        void push( Result& result, const Reference& ref );
+        void pushRef( Result& result, const QString& name );
         void pushHead( Result& result );
 
-        void hide( const ObjectId& id, Result& result );
-        void hide( const Reference& ref, Result& result );
-        void hideRef( const QString& name, Result& result );
+        void hide( Result& result, const ObjectId& id );
+        void hide( Result& result, const Reference& ref );
+        void hideRef( Result& result, const QString& name );
         void hideHead( Result& result );
 
-        bool next( ObjectId& oidNext, Result& result );
+        bool next( Result& result, ObjectId& oidNext );
         QVector< ObjectId > all( Result& result );
 
-        void setSorting( bool topological, bool timed, Result& result );
+        void setSorting( Result& result, bool topological, bool timed );
 
     private:
         Internal::GitPtr< Internal::RevisionWalkerPrivate > d;

--- a/libGitWrap/Signature.cpp
+++ b/libGitWrap/Signature.cpp
@@ -34,7 +34,7 @@ namespace Git
                 dt );
         }
 
-        git_signature* signature2git( const Signature& sig, Result& result )
+        git_signature* signature2git(Result& result, const Signature& sig)
         {
             if( !result )
             {

--- a/libGitWrap/TreeBuilder.cpp
+++ b/libGitWrap/TreeBuilder.cpp
@@ -88,7 +88,7 @@ namespace Git
         git_treebuilder_clear( d->mBuilder );
     }
 
-    bool TreeBuilder::remove( const QString& fileName, Result& result )
+    bool TreeBuilder::remove(Result& result, const QString& fileName)
     {
         if( !result )
         {
@@ -155,7 +155,7 @@ namespace Git
     }
 
 
-    TreeEntry TreeBuilder::get( const QString& name, Result& result )
+    TreeEntry TreeBuilder::get(Result& result, const QString& name)
     {
         if( !result )
         {

--- a/libGitWrap/TreeBuilder.hpp
+++ b/libGitWrap/TreeBuilder.hpp
@@ -48,10 +48,10 @@ namespace Git
 
         void clear( Result& result );
 
-        TreeEntry get( const QString& name, Result& result );
+        TreeEntry get( Result& result, const QString& name );
         bool insert( const QString& fileName, TreeEntryAttributes type, const ObjectId& oid,
                      Result& result );
-        bool remove( const QString& fileName, Result& result );
+        bool remove( Result& result, const QString& fileName );
         ObjectId write( Result& result );
 
     private:

--- a/libGitWrap/TreeBuilder.hpp
+++ b/libGitWrap/TreeBuilder.hpp
@@ -46,13 +46,13 @@ namespace Git
     public:
         bool isValid() const;
 
-        void clear( Result& result GITWRAP_DEFAULT_TLSRESULT );
+        void clear( Result& result );
 
-        TreeEntry get( const QString& name, Result& result GITWRAP_DEFAULT_TLSRESULT );
+        TreeEntry get( const QString& name, Result& result );
         bool insert( const QString& fileName, TreeEntryAttributes type, const ObjectId& oid,
-                     Result& result GITWRAP_DEFAULT_TLSRESULT );
-        bool remove( const QString& fileName, Result& result GITWRAP_DEFAULT_TLSRESULT );
-        ObjectId write( Result& result GITWRAP_DEFAULT_TLSRESULT );
+                     Result& result );
+        bool remove( const QString& fileName, Result& result );
+        ObjectId write( Result& result );
 
     private:
         Internal::GitPtr< Internal::TreeBuilderPrivate > d;


### PR DESCRIPTION
Refactured `Result` to be always the first parameter in GitWrap calls. Depends on refacturing branch `libMacGitverModules/refacture/ResultAsFirstParam`.

Please note, that this causes additional changes in current feature branches, that are in progress.
