### PR TITLE
Internal API to use ObjectID directly in place of git_oid*

### DIFF
--- a/libGitWrap/GitWrapPrivate.hpp
+++ b/libGitWrap/GitWrapPrivate.hpp
@@ -236,6 +236,11 @@ namespace Git
         {
             return (const git_oid* const) id.raw();
         }
+        
+        inline git_oid* ObjectId2git_oid(ObjectId& id)
+        {
+            return (git_oid*) id.rawWritable();
+        }
 
         /**
          * @internal

--- a/libGitWrap/GitWrapPrivate.hpp
+++ b/libGitWrap/GitWrapPrivate.hpp
@@ -24,6 +24,7 @@
 
 #include "GitWrap.hpp"
 #include "Result.hpp"
+#include "ObjectId.hpp"
 
 namespace Git
 {
@@ -230,6 +231,11 @@ namespace Git
 
             static GitWrapPrivate* self;    // Make this an QAtomicPointer
         };
+        
+        inline const git_oid* const ObjectId2git_oid(const ObjectId& id)
+        {
+            return (const git_oid* const) id.raw();
+        }
 
         /**
          * @internal

--- a/libGitWrap/ObjectId.hpp
+++ b/libGitWrap/ObjectId.hpp
@@ -60,6 +60,11 @@ namespace Git
         {
             return data;
         }
+        
+        unsigned char* rawWritable()
+        {
+            return data;
+        }
 
         bool isNull() const;
 


### PR DESCRIPTION
Adds an internal API to use our ObjectID directly in places where a `git_oid*` is required.

Use like:

```
void foo(const ObjectId& id) {
  git_something( ObjectId2git_oid(id) );
}
```

where `git_something` takes a `git_oid*` as input.
