### PR TITLE
Allow Git::ObjectId to be turned into short strings

### DIFF
--- a/libGitWrap/ObjectId.cpp
+++ b/libGitWrap/ObjectId.cpp
@@ -67,15 +67,16 @@ namespace Git
         return id;
     }
 
-    QString ObjectId::toString() const
+    QString ObjectId::toString(int max) const
     {
-        return QString::fromUtf8( toAscii().constData() );	// UTF-8 is Ascii, actually :-)
+        return QString::fromUtf8(toAscii(max).constData()); // UTF-8 is Ascii, actually :-)
     }
 
-    QByteArray ObjectId::toAscii() const
+    QByteArray ObjectId::toAscii(int max) const
     {
-        QByteArray id( SHA1_LengthHex + 1, 0 );
-        git_oid_tostr( id.data(), SHA1_LengthHex +  1, (const git_oid*) data );
+        max = qMax(0,qMin<int>(SHA1_LengthHex, max)) + 1;
+        QByteArray id(max, 0);
+        git_oid_tostr(id.data(), max, (const git_oid*) data);
         return id;
     }
 

--- a/libGitWrap/ObjectId.hpp
+++ b/libGitWrap/ObjectId.hpp
@@ -53,14 +53,14 @@ namespace Git
 
         static ObjectId fromRaw( const unsigned char* raw, int n = SHA1_Length );
 
-        QString toString() const;
-        QByteArray toAscii() const;
+        QString toString(int max = SHA1_LengthHex) const;
+        QByteArray toAscii(int max = SHA1_LengthHex) const;
 
         const unsigned char* raw() const
         {
             return data;
         }
-        
+
         unsigned char* rawWritable()
         {
             return data;


### PR DESCRIPTION
Sometimes (most of the time) we don't want all the 40 numbers of a full SHA. Instead of creating it fully and then cutting the unwanted part, allow to tell libGitWrap how much we want to.
