### PR TITLE
Fixing compare operators of Git::Reference

### DIFF
--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -77,6 +77,19 @@ namespace Git
         return !( *this == other );
     }
 
+    /**
+     * @brief   Compares two reference objects.
+     *          Note: References of different types are considered to be different.
+     *
+     * @param   other the reference to compare with
+     *
+     * @return  0 if pointing to the same destination, otherwise an ordered value
+     */
+    int Reference::compare(const Reference &other) const
+    {
+        return git_reference_cmp( d->mRef, other.d->mRef );
+    }
+
     bool Reference::isValid() const
     {
         return d;

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -69,10 +69,7 @@ namespace Git
 
     bool Reference::operator==(const Reference &other) const
     {
-        if( d && other.d )
-            return git_reference_cmp( d->mRef, other.d->mRef ) == 0;
-
-        return false;
+        return this == &other;
     }
 
     bool Reference::operator!=(const Reference &other) const

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -69,7 +69,7 @@ namespace Git
 
     bool Reference::operator==(const Reference &other) const
     {
-        return this == &other;
+        return d == other.d;
     }
 
     bool Reference::operator!=(const Reference &other) const

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -56,6 +56,8 @@ namespace Git
         bool operator==( const Reference& other ) const;
         bool operator!=( const Reference& other ) const;
 
+        int compare( const Reference& other ) const;
+
     public:
         bool isValid() const;
         QString name() const;


### PR DESCRIPTION
The first implementation of object comparison of two `Git::Reference` objects is wrong and error prone (sorry for that). Especially as we are working with smart pointers, we need to worry about when an object is marked equal. This PR adds a simple fix for comparing references of Git::Reference objects (sometimes I hate language :smile:). Question here: Should we compare the `d` member here?

To compare the destination (symbol or OID) of references, the new method `compare` should be used. This wraps exactly `git_reference_cmp` from lg2.

Note: This enforces a correction to the behaviour of the MGV module `RefsViews`, currently relying on the == operator.
