### PR TITLE
Cleanup QList usage and some stuff

### DIFF
--- a/libGitWrap/ChangeListConsumer.hpp
+++ b/libGitWrap/ChangeListConsumer.hpp
@@ -21,14 +21,12 @@
 
 namespace Git
 {
-    struct ChangeListEntry;
 
     /**
-     * @ingroup     GitWrap
-     * @brief       Callback interface to consume a list of differences
-     *
+     * @ingroup GitWrap
+     * @brief The ChangeListEntry struct keeps information about a single file change.
      */
-    class GITWRAP_API ChangeListConsumer
+    struct GITWRAP_API ChangeListEntry
     {
     public:
         enum Type
@@ -44,25 +42,29 @@ namespace Git
         };
 
     public:
+        QString         oldPath;
+        QString         newPath;
+        Type            type;
+        unsigned int    similarity;
+        bool            isBinary;
+    };
+
+    /**
+     * @ingroup     GitWrap
+     * @brief       Callback interface to consume a list of differences
+     *
+     */
+    class GITWRAP_API ChangeListConsumer
+    {
+    public:
+        typedef ChangeListEntry::Type Type; // For compat only
+
+    public:
         ChangeListConsumer();
         virtual ~ChangeListConsumer();
 
     public:
         virtual bool startFileChange( const ChangeListEntry &entry );
-
-    };
-
-    /**
-     * @ingroup GitWrap
-     * @brief The ChangeListEntry struct keeps information about a single file change.
-     */
-    struct GITWRAP_API ChangeListEntry
-    {
-        QString oldPath;
-        QString newPath;
-        ChangeListConsumer::Type type;
-        unsigned int similarity;
-        bool isBinary;
     };
 
 }

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -22,11 +22,6 @@
 namespace Git
 {
 
-    class Repository;
-    class ChangeListConsumer;
-    struct ChangeListEntry;
-    class PatchConsumer;
-
     namespace Internal
     {
         class DiffListPrivate;

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -27,8 +27,6 @@ namespace Git
         class DiffListPrivate;
     }
 
-    typedef QVector<ChangeListEntry> ChangeList;
-
     /**
      * @ingroup     GitWrap
      * @brief       List of differences between to objects

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -89,6 +89,27 @@ namespace Git
         SubmoduleAttr       = 0160000
     };
 
+    class ChangeListConsumer;
+    class DiffList;
+    class Index;
+    class IndexEntry;
+    class Object;
+    class ObjectBlob;
+    class ObjectCommit;
+    class ObjectId;
+    class ObjectTag;
+    class ObjectTree;
+    class PatchConsumer;
+    class RefSpec;
+    class Reference;
+    class Remote;
+    class Repository;
+    class RevisionWalker;
+    class Submodule;
+    class TreeBuilder;
+    class TreeEntry;
+    struct ChangeListEntry;
+
     /**
      * @enum        Status
      * @ingroup     GitWrap
@@ -234,6 +255,7 @@ namespace Git
     public:
         static Result& lastResult();
     };
+
 }
 
 #endif

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -115,6 +115,7 @@ namespace Git
     typedef QVector< ObjectId >         ObjectIdList;
     typedef QVector< Reference >        ReferenceList;
     typedef QVector< Submodule >        SubmoduleList;
+    typedef QVector< ObjectCommit >     ObjectCommitList;
 
     /**
      * @enum        Status

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -17,7 +17,8 @@
 #ifndef GITWRAP_GITWRAP_H
 #define GITWRAP_GITWRAP_H
 
-#include <QString>
+#include <QStringList>
+#include <QDateTime>
 #include <QHash>
 #include <QMetaType>
 #include <QVector>

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -111,6 +111,11 @@ namespace Git
     class TreeEntry;
     struct ChangeListEntry;
 
+    typedef QVector< ChangeListEntry >  ChangeList;
+    typedef QVector< ObjectId >         ObjectIdList;
+    typedef QVector< Reference >        ReferenceList;
+    typedef QVector< Submodule >        SubmoduleList;
+
     /**
      * @enum        Status
      * @ingroup     GitWrap

--- a/libGitWrap/GitWrapPrivate.hpp
+++ b/libGitWrap/GitWrapPrivate.hpp
@@ -18,7 +18,7 @@
 #define GIT_P_H
 
 #include <QThreadStorage>
-#include <QStringList>
+#include <QDebug>
 
 #include "git2.h"
 

--- a/libGitWrap/GitWrapPrivate.hpp
+++ b/libGitWrap/GitWrapPrivate.hpp
@@ -231,12 +231,12 @@ namespace Git
 
             static GitWrapPrivate* self;    // Make this an QAtomicPointer
         };
-        
+
         inline const git_oid* const ObjectId2git_oid(const ObjectId& id)
         {
             return (const git_oid* const) id.raw();
         }
-        
+
         inline git_oid* ObjectId2git_oid(ObjectId& id)
         {
             return (git_oid*) id.rawWritable();

--- a/libGitWrap/Index.hpp
+++ b/libGitWrap/Index.hpp
@@ -24,9 +24,6 @@
 namespace Git
 {
 
-    class IndexEntry;
-    class Repository;
-
     namespace Internal
     {
         class IndexPrivate;

--- a/libGitWrap/IndexEntry.hpp
+++ b/libGitWrap/IndexEntry.hpp
@@ -23,8 +23,6 @@
 
 #include "GitWrap.hpp"
 
-struct git_index_entry;
-
 namespace Git
 {
 

--- a/libGitWrap/IndexEntry.hpp
+++ b/libGitWrap/IndexEntry.hpp
@@ -19,8 +19,6 @@
 #ifndef GIT_INDEX_ENTRY_H
 #define GIT_INDEX_ENTRY_H
 
-#include <QTime>
-
 #include "GitWrap.hpp"
 
 namespace Git

--- a/libGitWrap/IndexEntry.hpp
+++ b/libGitWrap/IndexEntry.hpp
@@ -19,15 +19,14 @@
 #ifndef GIT_INDEX_ENTRY_H
 #define GIT_INDEX_ENTRY_H
 
-#include "GitWrap.hpp"
-
 #include <QTime>
+
+#include "GitWrap.hpp"
 
 struct git_index_entry;
 
 namespace Git
 {
-    class ObjectId;
 
     namespace Internal
     {

--- a/libGitWrap/Object.hpp
+++ b/libGitWrap/Object.hpp
@@ -28,13 +28,6 @@ namespace Git
         class ObjectPrivate;
     }
 
-    class ObjectTree;
-    class ObjectBlob;
-    class ObjectCommit;
-    class ObjectTag;
-
-    class Repository;
-
     /**
      * @brief The Object class is the base class for Git repository objects.
      *

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -440,3 +440,17 @@ namespace Git
     }
 
 }
+
+/**
+ * @ingroup     GitWrap
+ * @brief       Debug-Stream support of Git::ObjectCommit
+ * @param[in]   debug   The Debug-Stream to output into
+ * @param[in]   commit  The commit object to output
+ * @return      The Debug-Stream
+ */
+QDebug operator<<( QDebug debug, const Git::ObjectCommit& commit )
+{
+    Git::Result r;
+    return debug << "Commit(id=" << commit.id( r ) << ";author=" << commit.author( r ) << ")";
+}
+

--- a/libGitWrap/ObjectCommit.cpp
+++ b/libGitWrap/ObjectCommit.cpp
@@ -161,19 +161,19 @@ namespace Git
         return ObjectId();
     }
 
-    QVector< ObjectCommit > ObjectCommit::parentCommits( Result& result ) const
+    ObjectCommitList ObjectCommit::parentCommits( Result& result ) const
     {
         if( !result )
         {
-            return QVector< ObjectCommit >();
+            return ObjectCommitList();
         }
         if( !d )
         {
             result.setInvalidObject();
-            return QVector< ObjectCommit >();
+            return ObjectCommitList();
         }
 
-        QVector< ObjectCommit > objs;
+        ObjectCommitList objs;
 
         git_commit* commit = (git_commit*) d->mObj;
 
@@ -184,7 +184,7 @@ namespace Git
             result = git_commit_parent( &parent, commit, i );
             if( !result )
             {
-                return QVector< ObjectCommit >();
+                return ObjectCommitList();
             }
 
             objs.append( new Internal::ObjectPrivate( d->repo(), (git_object*) parent ) );

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -98,18 +98,6 @@ namespace Git
 
 }
 
-// Should we keep this? If yes, we should provide them for all GitWrap-classes.
-/**
- * @ingroup     GitWrap
- * @brief       Debug-Stream support of Git::ObjectCommit
- * @param[in]   debug   The Debug-Stream to output into
- * @param[in]   commit  The commit object to output
- * @return      The Debug-Stream
- */
-inline QDebug operator<<( QDebug debug, const Git::ObjectCommit& commit )
-{
-    Git::Result r;
-    return debug << "Commit(id=" << commit.id( r ) << ";author=" << commit.author( r ) << ")";
-}
+GITWRAP_API QDebug operator<<( QDebug debug, const Git::ObjectCommit& commit );
 
 #endif

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -29,9 +29,6 @@
 namespace Git
 {
 
-    class Reference;
-    class ObjectTree;
-
     /**
      * @ingroup     GitWrap
      * @brief       Represents a git commit object.

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -57,7 +57,7 @@ namespace Git
         ObjectId treeId( Result& result );
 
         ObjectIdList parentCommitIds( Result& result ) const;
-        QVector< ObjectCommit > parentCommits( Result& result ) const;
+        ObjectCommitList parentCommits( Result& result ) const;
         ObjectCommit parentCommit( Result& result, unsigned int index ) const;
         ObjectId parentCommitId( Result& result, unsigned int index ) const;
         unsigned int numParentCommits() const;

--- a/libGitWrap/ObjectCommit.hpp
+++ b/libGitWrap/ObjectCommit.hpp
@@ -17,8 +17,6 @@
 #ifndef GIT_OBJECT_COMMIT_H
 #define GIT_OBJECT_COMMIT_H
 
-#include <QStringList>
-
 #include "GitWrap.hpp"
 #include "ObjectId.hpp"
 #include "Object.hpp"

--- a/libGitWrap/ObjectId.cpp
+++ b/libGitWrap/ObjectId.cpp
@@ -14,8 +14,7 @@
  *
  */
 
-#include "git2.h"
-
+#include "GitWrapPrivate.hpp"
 #include "ObjectId.hpp"
 
 namespace Git

--- a/libGitWrap/ObjectId.cpp
+++ b/libGitWrap/ObjectId.cpp
@@ -117,3 +117,8 @@ namespace Git
     }
 
 }
+
+QDebug operator<<( QDebug debug, const Git::ObjectId& id )
+{
+    return debug << "SHA1(" << id.toString() << ")";
+}

--- a/libGitWrap/ObjectId.hpp
+++ b/libGitWrap/ObjectId.hpp
@@ -17,10 +17,6 @@
 #ifndef GIT_OBJECT_ID_H
 #define GIT_OBJECT_ID_H
 
-#include <QString>
-#include <QByteArray>
-#include <QDebug>
-
 #include "GitWrap.hpp"
 
 namespace Git

--- a/libGitWrap/ObjectId.hpp
+++ b/libGitWrap/ObjectId.hpp
@@ -81,10 +81,7 @@ namespace Git
 
 }
 
-inline QDebug operator<<( QDebug debug, const Git::ObjectId& id )
-{
-    return debug << "SHA1(" << id.toString() << ")";
-}
+GITWRAP_API QDebug operator<<( QDebug debug, const Git::ObjectId& id );
 
 Q_DECLARE_METATYPE( Git::ObjectId )
 

--- a/libGitWrap/ObjectId.hpp
+++ b/libGitWrap/ObjectId.hpp
@@ -71,8 +71,6 @@ namespace Git
         unsigned char data[ SHA1_Length ];
     };
 
-    typedef QVector< ObjectId > ObjectIdList;
-
     GITWRAP_API uint qHash( const ObjectId& sha1 );
 
 }

--- a/libGitWrap/ObjectTree.hpp
+++ b/libGitWrap/ObjectTree.hpp
@@ -25,8 +25,6 @@
 namespace Git
 {
 
-    class DiffList;
-
     /**
      * @ingroup     GitWrap
      * @brief       Represents a git tree object

--- a/libGitWrap/RefSpec.hpp
+++ b/libGitWrap/RefSpec.hpp
@@ -17,8 +17,6 @@
 #ifndef GIT_REFSPEC_H
 #define GIT_REFSPEC_H
 
-#include <QString>
-
 #include "GitWrap.hpp"
 
 namespace Git

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -24,10 +24,6 @@
 namespace Git
 {
 
-    class ObjectCommit;
-    class ObjectId;
-    class Repository;
-
     namespace Internal
     {
         class ReferencePrivate;

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -19,8 +19,6 @@
 
 #include "GitWrap.hpp"
 
-#include <QStringList>
-
 namespace Git
 {
 

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -27,10 +27,6 @@ namespace Git
         class RemotePrivate;
     }
 
-    class ObjectId;
-    class Reference;
-    class RefSpec;
-
     /**
      * @ingroup     GitWrap
      * @brief       Represents a git remote.

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -970,45 +970,44 @@ namespace Git
 
         struct cb_enum_submodules_t
         {
-            QList< Submodule >*	subs;
-            RepositoryPrivate*	repo;
+            RepositoryPrivate*  repo;
+            Submodule::List     subs;
         };
 
         static int cb_enum_submodules( git_submodule* sm, const char* name, void* payload )
         {
             cb_enum_submodules_t* d = static_cast< cb_enum_submodules_t* >( payload );
-            Q_ASSERT( d && d->subs && name );
+            Q_ASSERT( d && name );
 
-            d->subs->append( Submodule( d->repo, QString::fromUtf8( name ) ) );
+            d->subs.append( Submodule( d->repo, QString::fromUtf8( name ) ) );
             return 0;
         }
 
     }
 
-    QList< Submodule > Repository::submodules( Result& result )
+    Submodule::List Repository::submodules( Result& result )
     {
-        QList< Submodule > list;
+        Internal::cb_enum_submodules_t data = { d };
 
         if( !result )
         {
-            return list;
+            return data.subs;
         }
 
         if( !d )
         {
             result.setInvalidObject();
-            return list;
+            return data.subs;
         }
 
-        Internal::cb_enum_submodules_t data = { &list, d };
 
         result = git_submodule_foreach( d->mRepo, &Internal::cb_enum_submodules, &data );
         if( !result )
         {
-            return QList< Submodule >();
+            return Submodule::List();
         }
 
-        return list;
+        return data.subs;
     }
 
     Submodule Repository::submodule(Result& result, const QString& name)

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -28,8 +28,6 @@ namespace Git
     }
 
     typedef QHash< QString, ObjectId > ResolvedRefs;
-    typedef QList< Reference > ReferenceList;
-
 
     /**
      * @ingroup     GitWrap

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -24,18 +24,6 @@
 namespace Git
 {
 
-    class Reference;
-    class DiffList;
-    class Index;
-    class Object;
-    class ObjectCommit;
-    class ObjectTag;
-    class ObjectBlob;
-    class ObjectTree;
-    class ObjectId;
-    class RevisionWalker;
-    class Remote;
-
     namespace Internal
     {
         class RepositoryPrivate;

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -17,8 +17,6 @@
 #ifndef GIT_REPOSITORY_H
 #define GIT_REPOSITORY_H
 
-#include <QStringList>
-
 #include "Submodule.hpp"
 
 namespace Git

--- a/libGitWrap/Result.cpp
+++ b/libGitWrap/Result.cpp
@@ -14,8 +14,6 @@
  *
  */
 
-#include <QDebug>
-
 #include "GitWrapPrivate.hpp"
 
 #include "Result.hpp"

--- a/libGitWrap/Result.hpp
+++ b/libGitWrap/Result.hpp
@@ -17,8 +17,6 @@
 #ifndef GIT_ERROR_H
 #define GIT_ERROR_H
 
-#include <QString>
-
 #include "GitWrap.hpp"
 
 namespace Git

--- a/libGitWrap/RevisionWalker.hpp
+++ b/libGitWrap/RevisionWalker.hpp
@@ -27,9 +27,6 @@ namespace Git
         class RevisionWalkerPrivate;
     }
 
-    class ObjectId;
-    class Reference;
-
     /**
      * @ingroup     GitWrap
      * @brief       Provides access to a git repository's history

--- a/libGitWrap/Signature.cpp
+++ b/libGitWrap/Signature.cpp
@@ -56,3 +56,7 @@ namespace Git
 
 }
 
+QDebug operator<<( QDebug debug, const Git::Signature& sig )
+{
+    return debug << "Sig(" << sig.toNaturalString() << ")";
+}

--- a/libGitWrap/Signature.hpp
+++ b/libGitWrap/Signature.hpp
@@ -117,10 +117,6 @@ namespace Git
 
 }
 
-inline QDebug operator<<( QDebug debug, const Git::Signature& sig )
-{
-    return debug << "Sig(" << sig.toNaturalString() << ")";
-}
-
+GITWRAP_API QDebug operator<<( QDebug debug, const Git::Signature& sig );
 
 #endif

--- a/libGitWrap/Signature.hpp
+++ b/libGitWrap/Signature.hpp
@@ -17,11 +17,6 @@
 #ifndef GIT_SIGNATURE_H
 #define GIT_SIGNATURE_H
 
-#include <QDebug>
-
-#include <QString>
-#include <QDateTime>
-
 #include "GitWrap.hpp"
 
 namespace Git

--- a/libGitWrap/Submodule.hpp
+++ b/libGitWrap/Submodule.hpp
@@ -57,6 +57,12 @@ namespace Git
 
     public:
         /**
+         * @brief       A list of submodules
+         */
+        typedef QVector< Submodule > List;
+
+    public:
+        /**
          * @brief Submodule
          * @param repo the owner repository
          * @param name is used to lookup the submodule in the owner repository
@@ -131,7 +137,7 @@ namespace Git
         Internal::GitPtr< Internal::SubmodulePrivate > d;
     };
 
-    typedef QList< Submodule > SubmoduleList;
+    typedef Submodule::List SubmoduleList;
 
 }
 

--- a/libGitWrap/Submodule.hpp
+++ b/libGitWrap/Submodule.hpp
@@ -56,7 +56,7 @@ namespace Git
         /**
          * @brief       A list of submodules
          */
-        typedef QVector< Submodule > List;
+        typedef SubmoduleList List;
 
     public:
         /**
@@ -133,8 +133,6 @@ namespace Git
     private:
         Internal::GitPtr< Internal::SubmodulePrivate > d;
     };
-
-    typedef Submodule::List SubmoduleList;
 
 }
 

--- a/libGitWrap/Submodule.hpp
+++ b/libGitWrap/Submodule.hpp
@@ -28,9 +28,6 @@ namespace Git
         class SubmodulePrivate;
     }
 
-    class ObjectId;
-    class Repository;
-
     /**
      * @ingroup     GitWrap
      * @brief       Represents a git submodule

--- a/libGitWrap/TreeBuilder.hpp
+++ b/libGitWrap/TreeBuilder.hpp
@@ -27,9 +27,6 @@ namespace Git
         class TreeBuilderPrivate;
     }
 
-    class TreeEntry;
-    class ObjectId;
-
     /**
      * @ingroup     GitWrap
      * @brief       Tool for creating tree objects

--- a/libGitWrap/TreeEntry.hpp
+++ b/libGitWrap/TreeEntry.hpp
@@ -27,8 +27,6 @@ namespace Git
         class TreeEntryPrivate;
     }
 
-    class ObjectId;
-
     /**
      * @ingroup     GitWrap
      * @brief       Represents an entry in a git tree


### PR DESCRIPTION
@antis81, could you have a short look over this. It does:
- Move all libGitWrap object forward declarations into a central place in GitWrap.hpp
- Changes all remaining usages of QList with QVector
- Does proper typedef declarations for all Lists
- Makes qDebug() macros published code instead of inline
- Do Qt-Includes centraly (the ones we need for API in GitWrap.hpp, most others privately in .cpp)
- Doesn't include <QDebug> in a global scope (early on). Most of our code doesn't use QDebug and where we do, we can as well include it explicitly.
