### PR TITLE
removed deprecated call of repository()

### DIFF
--- a/libGitWrap/RepoObject.cpp
+++ b/libGitWrap/RepoObject.cpp
@@ -52,11 +52,6 @@ namespace Git
 
     GW_PRIVATE_IMPL(RepoObject, Base)
 
-    Repository RepoObject::repository(Result &result) const
-    {
-        return repository();
-    }
-
     Repository RepoObject::repository() const
     {
         GW_CD(RepoObject);

--- a/libGitWrap/RepoObject.hpp
+++ b/libGitWrap/RepoObject.hpp
@@ -36,7 +36,6 @@ namespace Git
     {
         GW_PRIVATE_DECL(RepoObject, Base, protected)
     public:
-        GW_DEPRECATED Repository repository(Result &result) const;
         Repository repository() const;
     };
 


### PR DESCRIPTION
Removed the deprecated call to repository(). Seems to be :ok: so far.
