### PR TITLE
String wrapper to convert between QString and lg2

### DIFF
--- a/libGitWrap/Commit.cpp
+++ b/libGitWrap/Commit.cpp
@@ -112,9 +112,9 @@ namespace Git
         if (!result) return Commit();
 
         git_oid commitId;
-        result = git_commit_create( &commitId, rp->mRepo, Internal::StringHelper(branchName),
+        result = git_commit_create( &commitId, rp->mRepo, GW_StringFromQt(branchName),
                                     gitAuthor, gitCommitter,
-                                    NULL, Internal::StringHelper(message), Private::dataOf<Tree>(tree)->o(),
+                                    NULL, GW_StringFromQt(message), Private::dataOf<Tree>(tree)->o(),
                                     parents.count(), constParents.data() );
 
         return repo.lookupCommit( result, ObjectId::fromRaw(commitId.id) );
@@ -161,9 +161,9 @@ namespace Git
         if (!result) return Commit();
 
         git_oid commitId;
-        result = git_commit_create_from_ids( &commitId, rp->mRepo, Internal::StringHelper(branchName),
+        result = git_commit_create_from_ids( &commitId, rp->mRepo, GW_StringFromQt(branchName),
                                              gitAuthor, gitCommitter,
-                                             NULL, Internal::StringHelper(message),
+                                             NULL, GW_StringFromQt(message),
                                              Internal::ObjectId2git_oid(tree.id()),
                                              parents.count(), constParents.data() );
 
@@ -342,7 +342,7 @@ namespace Git
             len--;
         }
 
-        return Internal::StringHelper(msg, len);
+        return GW_StringToQt(msg, len);
     }
 
     QString Commit::shortMessage() const
@@ -359,7 +359,7 @@ namespace Git
             len++;
         }
 
-        return Internal::StringHelper(msg, len);
+        return GW_StringToQt(msg, len);
     }
 
     /**
@@ -406,7 +406,7 @@ namespace Git
         GW_CD_CHECKED(Commit, Reference(), result);
 
         git_reference* ref = NULL;
-        result = git_branch_create( &ref, d->repo()->mRepo, Internal::StringHelper(name), d->o(), force, NULL, NULL );
+        result = git_branch_create( &ref, d->repo()->mRepo, GW_StringFromQt(name), d->o(), force, NULL, NULL );
 
         if (!result) {
             return Reference();

--- a/libGitWrap/Commit.cpp
+++ b/libGitWrap/Commit.cpp
@@ -112,9 +112,9 @@ namespace Git
         if (!result) return Commit();
 
         git_oid commitId;
-        result = git_commit_create( &commitId, rp->mRepo, branchName.toUtf8().constData(),
+        result = git_commit_create( &commitId, rp->mRepo, Internal::String(branchName),
                                     gitAuthor, gitCommitter,
-                                    NULL, message.toUtf8().constData(), Private::dataOf<Tree>(tree)->o(),
+                                    NULL, Internal::String(message), Private::dataOf<Tree>(tree)->o(),
                                     parents.count(), constParents.data() );
 
         return repo.lookupCommit( result, ObjectId::fromRaw(commitId.id) );
@@ -161,9 +161,9 @@ namespace Git
         if (!result) return Commit();
 
         git_oid commitId;
-        result = git_commit_create_from_ids( &commitId, rp->mRepo, branchName.toUtf8().constData(),
+        result = git_commit_create_from_ids( &commitId, rp->mRepo, Internal::String(branchName),
                                              gitAuthor, gitCommitter,
-                                             NULL, message.toUtf8().constData(),
+                                             NULL, Internal::String(message),
                                              Internal::ObjectId2git_oid(tree.id()),
                                              parents.count(), constParents.data() );
 
@@ -342,7 +342,7 @@ namespace Git
             len--;
         }
 
-        return QString::fromUtf8(msg, len);
+        return Internal::String(msg, len);
     }
 
     QString Commit::shortMessage() const
@@ -359,7 +359,7 @@ namespace Git
             len++;
         }
 
-        return QString::fromUtf8(msg, len);
+        return Internal::String(msg, len);
     }
 
     /**
@@ -406,7 +406,7 @@ namespace Git
         GW_CD_CHECKED(Commit, Reference(), result);
 
         git_reference* ref = NULL;
-        result = git_branch_create( &ref, d->repo()->mRepo, name.toUtf8().constData(), d->o(), force, NULL, NULL );
+        result = git_branch_create( &ref, d->repo()->mRepo, Internal::String(name), d->o(), force, NULL, NULL );
 
         if (!result) {
             return Reference();

--- a/libGitWrap/Commit.cpp
+++ b/libGitWrap/Commit.cpp
@@ -112,9 +112,9 @@ namespace Git
         if (!result) return Commit();
 
         git_oid commitId;
-        result = git_commit_create( &commitId, rp->mRepo, Internal::String(branchName),
+        result = git_commit_create( &commitId, rp->mRepo, Internal::StringHelper(branchName),
                                     gitAuthor, gitCommitter,
-                                    NULL, Internal::String(message), Private::dataOf<Tree>(tree)->o(),
+                                    NULL, Internal::StringHelper(message), Private::dataOf<Tree>(tree)->o(),
                                     parents.count(), constParents.data() );
 
         return repo.lookupCommit( result, ObjectId::fromRaw(commitId.id) );
@@ -161,9 +161,9 @@ namespace Git
         if (!result) return Commit();
 
         git_oid commitId;
-        result = git_commit_create_from_ids( &commitId, rp->mRepo, Internal::String(branchName),
+        result = git_commit_create_from_ids( &commitId, rp->mRepo, Internal::StringHelper(branchName),
                                              gitAuthor, gitCommitter,
-                                             NULL, Internal::String(message),
+                                             NULL, Internal::StringHelper(message),
                                              Internal::ObjectId2git_oid(tree.id()),
                                              parents.count(), constParents.data() );
 
@@ -342,7 +342,7 @@ namespace Git
             len--;
         }
 
-        return Internal::String(msg, len);
+        return Internal::StringHelper(msg, len);
     }
 
     QString Commit::shortMessage() const
@@ -359,7 +359,7 @@ namespace Git
             len++;
         }
 
-        return Internal::String(msg, len);
+        return Internal::StringHelper(msg, len);
     }
 
     /**
@@ -406,7 +406,7 @@ namespace Git
         GW_CD_CHECKED(Commit, Reference(), result);
 
         git_reference* ref = NULL;
-        result = git_branch_create( &ref, d->repo()->mRepo, Internal::String(name), d->o(), force, NULL, NULL );
+        result = git_branch_create( &ref, d->repo()->mRepo, Internal::StringHelper(name), d->o(), force, NULL, NULL );
 
         if (!result) {
             return Reference();

--- a/libGitWrap/Config.cpp
+++ b/libGitWrap/Config.cpp
@@ -182,8 +182,8 @@ namespace Git
     static int read_config_cb( const git_config_entry* entry, void* data )
     {
         ConfigValues* cv = (ConfigValues*) data;
-        cv->insert( Internal::String( entry->name ),
-                    Internal::String( entry->value ) );
+        cv->insert( Internal::StringHelper( entry->name ),
+                    Internal::StringHelper( entry->value ) );
         return 0;
     }
 

--- a/libGitWrap/Config.cpp
+++ b/libGitWrap/Config.cpp
@@ -182,8 +182,8 @@ namespace Git
     static int read_config_cb( const git_config_entry* entry, void* data )
     {
         ConfigValues* cv = (ConfigValues*) data;
-        cv->insert( QString::fromUtf8( entry->name ),
-                    QString::fromUtf8( entry->value ) );
+        cv->insert( Internal::String( entry->name ),
+                    Internal::String( entry->value ) );
         return 0;
     }
 

--- a/libGitWrap/Config.cpp
+++ b/libGitWrap/Config.cpp
@@ -182,8 +182,8 @@ namespace Git
     static int read_config_cb( const git_config_entry* entry, void* data )
     {
         ConfigValues* cv = (ConfigValues*) data;
-        cv->insert( Internal::StringHelper( entry->name ),
-                    Internal::StringHelper( entry->value ) );
+        cv->insert( GW_StringToQt( entry->name ),
+                    GW_StringToQt( entry->value ) );
         return 0;
     }
 

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -74,8 +74,8 @@ namespace Git
 
             ChangeListEntry entry =
             {
-                QString::fromUtf8( delta->old_file.path )
-                , QString::fromUtf8( delta->new_file.path )
+                Internal::String( delta->old_file.path )
+                , Internal::String( delta->new_file.path )
                 , PatchConsumer::Type( delta->status )
                 , delta->similarity
                 , ( delta->flags & GIT_DIFF_FLAG_BINARY ) != 0
@@ -97,7 +97,7 @@ namespace Git
             QString header;
 
             if (hunk->header) {
-                header = QString::fromUtf8(hunk->header, int(hunk->header_len));
+                header = Internal::String::convert(hunk->header, int(hunk->header_len));
             }
 
             if (pc->startHunkChange(hunk->new_start, hunk->new_lines,
@@ -125,7 +125,7 @@ namespace Git
                     --len;
                 }
 
-                ct = QString::fromUtf8(line->content, len);
+                ct = Internal::String::convert(line->content, len);
             }
 
             switch(line->origin) {
@@ -159,8 +159,8 @@ namespace Git
 
             ChangeListEntry change =
             {
-                QString::fromUtf8( delta->old_file.path )
-                , QString::fromUtf8( delta->new_file.path )
+                Internal::String( delta->old_file.path )
+                , Internal::String( delta->new_file.path )
                 , ChangeListConsumer::Type( delta->status )
                 , delta->similarity
                 , ( delta->flags & GIT_DIFF_FLAG_BINARY ) != 0

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -74,8 +74,8 @@ namespace Git
 
             ChangeListEntry entry =
             {
-                Internal::StringHelper( delta->old_file.path )
-                , Internal::StringHelper( delta->new_file.path )
+                GW_StringToQt( delta->old_file.path )
+                , GW_StringToQt( delta->new_file.path )
                 , PatchConsumer::Type( delta->status )
                 , delta->similarity
                 , ( delta->flags & GIT_DIFF_FLAG_BINARY ) != 0
@@ -97,7 +97,7 @@ namespace Git
             QString header;
 
             if (hunk->header) {
-                header = Internal::StringHelper::convert(hunk->header, int(hunk->header_len));
+                header = GW_StringToQt(hunk->header, int(hunk->header_len));
             }
 
             if (pc->startHunkChange(hunk->new_start, hunk->new_lines,
@@ -125,7 +125,7 @@ namespace Git
                     --len;
                 }
 
-                ct = Internal::StringHelper::convert(line->content, len);
+                ct = GW_StringToQt(line->content);
             }
 
             switch(line->origin) {
@@ -159,8 +159,8 @@ namespace Git
 
             ChangeListEntry change =
             {
-                Internal::StringHelper( delta->old_file.path )
-                , Internal::StringHelper( delta->new_file.path )
+                GW_StringToQt( delta->old_file.path )
+                , GW_StringToQt( delta->new_file.path )
                 , ChangeListConsumer::Type( delta->status )
                 , delta->similarity
                 , ( delta->flags & GIT_DIFF_FLAG_BINARY ) != 0

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -74,8 +74,8 @@ namespace Git
 
             ChangeListEntry entry =
             {
-                Internal::String( delta->old_file.path )
-                , Internal::String( delta->new_file.path )
+                Internal::StringHelper( delta->old_file.path )
+                , Internal::StringHelper( delta->new_file.path )
                 , PatchConsumer::Type( delta->status )
                 , delta->similarity
                 , ( delta->flags & GIT_DIFF_FLAG_BINARY ) != 0
@@ -97,7 +97,7 @@ namespace Git
             QString header;
 
             if (hunk->header) {
-                header = Internal::String::convert(hunk->header, int(hunk->header_len));
+                header = Internal::StringHelper::convert(hunk->header, int(hunk->header_len));
             }
 
             if (pc->startHunkChange(hunk->new_start, hunk->new_lines,
@@ -125,7 +125,7 @@ namespace Git
                     --len;
                 }
 
-                ct = Internal::String::convert(line->content, len);
+                ct = Internal::StringHelper::convert(line->content, len);
             }
 
             switch(line->origin) {
@@ -159,8 +159,8 @@ namespace Git
 
             ChangeListEntry change =
             {
-                Internal::String( delta->old_file.path )
-                , Internal::String( delta->new_file.path )
+                Internal::StringHelper( delta->old_file.path )
+                , Internal::StringHelper( delta->new_file.path )
                 , ChangeListConsumer::Type( delta->status )
                 , delta->similarity
                 , ( delta->flags & GIT_DIFF_FLAG_BINARY ) != 0

--- a/libGitWrap/Events/Private/RemoteCallbacks.cpp
+++ b/libGitWrap/Events/Private/RemoteCallbacks.cpp
@@ -117,7 +117,7 @@ namespace Git
             debugEvents( "Remote Progress: %s", QByteArray( str, len ).constData() );
 
             if (events) {
-                events->remoteMessage(Internal::String(str, len));
+                events->remoteMessage(Internal::StringHelper(str, len));
             }
 
             return GITERR_NONE;
@@ -137,7 +137,7 @@ namespace Git
                         oidTo.toAscii().constData());
 
             if (events) {
-                events->updateTip(Internal::String(refname), oidFrom, oidTo);
+                events->updateTip(Internal::StringHelper(refname), oidFrom, oidTo);
             }
 
             return 0;

--- a/libGitWrap/Events/Private/RemoteCallbacks.cpp
+++ b/libGitWrap/Events/Private/RemoteCallbacks.cpp
@@ -117,7 +117,7 @@ namespace Git
             debugEvents( "Remote Progress: %s", QByteArray( str, len ).constData() );
 
             if (events) {
-                events->remoteMessage(QString::fromUtf8(str, len));
+                events->remoteMessage(Internal::String(str, len));
             }
 
             return GITERR_NONE;
@@ -137,7 +137,7 @@ namespace Git
                         oidTo.toAscii().constData());
 
             if (events) {
-                events->updateTip(QString::fromUtf8(refname), oidFrom, oidTo);
+                events->updateTip(Internal::String(refname), oidFrom, oidTo);
             }
 
             return 0;

--- a/libGitWrap/Events/Private/RemoteCallbacks.cpp
+++ b/libGitWrap/Events/Private/RemoteCallbacks.cpp
@@ -117,7 +117,7 @@ namespace Git
             debugEvents( "Remote Progress: %s", QByteArray( str, len ).constData() );
 
             if (events) {
-                events->remoteMessage(Internal::StringHelper(str, len));
+                events->remoteMessage(GW_StringToQt(str, len));
             }
 
             return GITERR_NONE;
@@ -137,7 +137,7 @@ namespace Git
                         oidTo.toAscii().constData());
 
             if (events) {
-                events->updateTip(Internal::StringHelper(refname), oidFrom, oidTo);
+                events->updateTip(GW_StringToQt(refname), oidFrom, oidTo);
             }
 
             return 0;

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -40,7 +40,7 @@ namespace Git
 
             for( unsigned int i = 0; i < arry->count; i++ )
             {
-                sl << Internal::StringHelper( arry->strings[ i ] );
+                sl << GW_StringToQt( arry->strings[ i ] );
             }
 
             git_strarray_free( arry );
@@ -216,7 +216,7 @@ namespace Git
 
             QString path;
             if (df->path) {
-                path = Internal::StringHelper::convert(df->path);
+                path = GW_StringToQt(df->path);
             }
             return FileInfo(path, ObjectId::fromRaw(df->id.id), df->size, FileModes(df->mode),
                             false, (df->flags & GIT_DIFF_FLAG_VALID_ID) != 0);

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -98,7 +98,7 @@ namespace Git
 
         //-- String ------------------------------------------------------------------------------>8
 
-        String::String(const QString& str, QTextCodec* codec)
+        String::String(QString str, QTextCodec* codec)
             : mStr(str)
             , mCodec(codec)
         {
@@ -115,9 +115,28 @@ namespace Git
             mStr = convert( str, size, codec );
         }
 
-        String::operator QString()
+        QString String::convert(const char* str, int size, QTextCodec* codec )
         {
-            return mStr;
+            return codec ? codec->toUnicode( str, size )
+                         : QString::fromUtf8( str, size );
+        }
+
+        QString String::convert(const char* str, QTextCodec* codec )
+        {
+            return codec ? codec->toUnicode( str )
+                         : QString::fromUtf8( str );
+        }
+
+        const char* String::convert()
+        {
+            mConvertedStr = toArray();
+            return mConvertedStr.constData();
+        }
+
+        QByteArray String::toArray() const
+        {
+            return mCodec ? mCodec->fromUnicode( mStr )
+                          : mStr.toUtf8();
         }
 
         String::String(const String& other)
@@ -131,34 +150,20 @@ namespace Git
             return *this;
         }
 
-        QString String::convert(const char* str, int size, QTextCodec* codec )
+        String::operator const char*()
         {
-            return codec ? codec->toUnicode( str, size )
-                         : QString::fromUtf8( str, size );
-        }
-
-        QString String::convert(const char* str, QTextCodec* codec )
-        {
-            return codec ? codec->toUnicode( str )
-                         : QString::fromUtf8( str );
-        }
-
-        const char* String::convert(const QString& str, QTextCodec* codec )
-        {
-            return codec ? codec->fromUnicode( str ).constData()
-                         : str.toUtf8().constData();
-        }
-
-        String::operator const char*() const
-        {
-            return convert( mStr, mCodec );
+            return convert();
         }
 
         String::operator char*()
         {
-            return const_cast<char*>( convert( mStr, mCodec ) );
+            return const_cast<char*>( convert() );
         }
 
+        String::operator QString()
+        {
+            return mStr;
+        }
 
         //-- StrArrayWrapper -------------------------------------------------------------------- >8
 

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -80,7 +80,7 @@ namespace Git
          */
         QString Buffer::toString() const
         {
-            return StringHelper( buf.ptr, buf.size );
+            return GW_StringToQt( buf.ptr, buf.size );
         }
 
 

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -80,8 +80,7 @@ namespace Git
          */
         QString Buffer::toString() const
         {
-            return mCodec ? mCodec->toUnicode( buf.ptr, buf.size )
-                          : QString::fromUtf8( buf.ptr, buf.size );
+            return String( buf.ptr, buf.size );
         }
 
         Buffer::Buffer(const Buffer& other)
@@ -94,6 +93,70 @@ namespace Git
             memcpy( buf.ptr, other.buf.ptr, other.buf.size );
             buf.asize = other.buf.asize;
             return *this;
+        }
+
+
+        //-- String ------------------------------------------------------------------------------>8
+
+        String::String(const QString& str, QTextCodec* codec)
+            : mStr(str)
+            , mCodec(codec)
+        {
+        }
+
+        String::String(const char* str, QTextCodec* codec)
+            : mCodec(codec)
+        {
+            mStr = convert( str, codec );
+        }
+
+        String::String(const char* str, int size, QTextCodec* codec)
+        {
+            mStr = convert( str, size, codec );
+        }
+
+        String::operator QString()
+        {
+            return mStr;
+        }
+
+        String::String(const String& other)
+        {
+            *this = other;
+        }
+
+        String& String::operator =(const String& other)
+        {
+            *this = other;
+            return *this;
+        }
+
+        QString String::convert(const char* str, int size, QTextCodec* codec )
+        {
+            return codec ? codec->toUnicode( str, size )
+                         : QString::fromUtf8( str, size );
+        }
+
+        QString String::convert(const char* str, QTextCodec* codec )
+        {
+            return codec ? codec->toUnicode( str )
+                         : QString::fromUtf8( str );
+        }
+
+        const char* String::convert(const QString& str, QTextCodec* codec )
+        {
+            return codec ? codec->fromUnicode( str ).constData()
+                         : str.toUtf8().constData();
+        }
+
+        String::operator const char*() const
+        {
+            return convert( mStr, mCodec );
+        }
+
+        String::operator char*()
+        {
+            return const_cast<char*>( convert( mStr, mCodec ) );
         }
 
 

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -123,24 +123,27 @@ namespace Git
             return QString::fromUtf8( str );
         }
 
-        const char* String::convert()
+        const char* String::convert() const
         {
-            mConvertedStr = toArray();
-            return mConvertedStr.constData();
+            if ( mConvertedStr.isEmpty() && !mStr.isEmpty())
+            {
+                mConvertedStr = toArray();
+            }
 
+            return mConvertedStr.constData();
         }
 
-        String::operator const char*()
+        String::operator const char*() const
         {
             return convert();
         }
 
-        String::operator char*()
+        String::operator char*() const
         {
             return const_cast<char*>( convert() );
         }
 
-        String::operator QString()
+        String::operator QString() const
         {
             return mStr;
         }

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -40,7 +40,7 @@ namespace Git
 
             for( unsigned int i = 0; i < arry->count; i++ )
             {
-                sl << Internal::String( arry->strings[ i ] );
+                sl << Internal::StringHelper( arry->strings[ i ] );
             }
 
             git_strarray_free( arry );
@@ -80,7 +80,7 @@ namespace Git
          */
         QString Buffer::toString() const
         {
-            return String( buf.ptr, buf.size );
+            return StringHelper( buf.ptr, buf.size );
         }
 
         Buffer::Buffer(const Buffer& other)
@@ -98,32 +98,32 @@ namespace Git
 
         //-- String ------------------------------------------------------------------------------>8
 
-        String::String(QString str)
+        StringHelper::StringHelper(QString str)
             : mStr(str)
         {
         }
 
-        String::String(const char* str)
+        StringHelper::StringHelper(const char* str)
         {
             mStr = convert( str );
         }
 
-        String::String(const char* str, int size)
+        StringHelper::StringHelper(const char* str, int size)
         {
             mStr = convert( str, size );
         }
 
-        QString String::convert(const char* str, int size )
+        QString StringHelper::convert(const char* str, int size )
         {
             return QString::fromUtf8( str, size );
         }
 
-        QString String::convert(const char* str)
+        QString StringHelper::convert(const char* str)
         {
             return QString::fromUtf8( str );
         }
 
-        const char* String::convert() const
+        const char* StringHelper::convert() const
         {
             if ( mConvertedStr.isEmpty() && !mStr.isEmpty())
             {
@@ -133,17 +133,17 @@ namespace Git
             return mConvertedStr.constData();
         }
 
-        String::operator const char*() const
+        StringHelper::operator const char*() const
         {
             return convert();
         }
 
-        String::operator char*() const
+        StringHelper::operator char*() const
         {
             return const_cast<char*>( convert() );
         }
 
-        String::operator QString() const
+        StringHelper::operator QString() const
         {
             return mStr;
         }
@@ -228,7 +228,7 @@ namespace Git
 
             QString path;
             if (df->path) {
-                path = Internal::String::convert(df->path);
+                path = Internal::StringHelper::convert(df->path);
             }
             return FileInfo(path, ObjectId::fromRaw(df->id.id), df->size, FileModes(df->mode),
                             false, (df->flags & GIT_DIFF_FLAG_VALID_ID) != 0);

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -84,65 +84,12 @@ namespace Git
         }
 
 
-        //-- String ------------------------------------------------------------------------------>8
-
-        StringHelper::StringHelper(QString str)
-            : mStr(str)
-        {
-        }
-
-        StringHelper::StringHelper(const char* str)
-        {
-            mStr = convert( str );
-        }
-
-        StringHelper::StringHelper(const char* str, int size)
-        {
-            mStr = convert( str, size );
-        }
-
-        QString StringHelper::convert(const char* str, int size )
-        {
-            return QString::fromUtf8( str, size );
-        }
-
-        QString StringHelper::convert(const char* str)
-        {
-            return QString::fromUtf8( str );
-        }
-
-        const char* StringHelper::convert() const
-        {
-            if ( mConvertedStr.isEmpty() && !mStr.isEmpty())
-            {
-                mConvertedStr = toArray();
-            }
-
-            return mConvertedStr.constData();
-        }
-
-        StringHelper::operator const char*() const
-        {
-            return convert();
-        }
-
-        StringHelper::operator char*() const
-        {
-            return const_cast<char*>( convert() );
-        }
-
-        StringHelper::operator QString() const
-        {
-            return mStr;
-        }
-
         //-- StrArray --------------------------------------------------------------------------- >8
 
         StrArray::StrArray()
         {
             Q_ASSERT(false);
         }
-
 
         StrArray::StrArray(const QStringList& sl)
         {

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -40,7 +40,7 @@ namespace Git
 
             for( unsigned int i = 0; i < arry->count; i++ )
             {
-                sl << QString::fromUtf8( arry->strings[ i ] );
+                sl << Internal::String( arry->strings[ i ] );
             }
 
             git_strarray_free( arry );
@@ -245,7 +245,7 @@ namespace Git
 
             QString path;
             if (df->path) {
-                path = QString::fromUtf8(df->path);
+                path = Internal::String::convert(df->path);
             }
             return FileInfo(path, ObjectId::fromRaw(df->id.id), df->size, FileModes(df->mode),
                             false, (df->flags & GIT_DIFF_FLAG_VALID_ID) != 0);

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -136,25 +136,25 @@ namespace Git
             return mStr;
         }
 
-        //-- StrArrayWrapper -------------------------------------------------------------------- >8
+        //-- StrArray --------------------------------------------------------------------------- >8
 
-        StrArrayWrapper::StrArrayWrapper()
+        StrArray::StrArray()
         {
             Q_ASSERT(false);
         }
 
-        StrArrayWrapper::StrArrayWrapper( const StrArrayWrapper & )
+        StrArray::StrArray( const StrArray & )
         {
             Q_ASSERT(false);
         }
 
-        StrArrayWrapper& StrArrayWrapper::operator=(const StrArrayWrapper&)
+        StrArray& StrArray::operator=(const StrArray&)
         {
             Q_ASSERT(false);
             return *this;
         }
 
-        StrArrayWrapper::StrArrayWrapper(const QStringList& sl)
+        StrArray::StrArray(const QStringList& sl)
         {
             internalCopy = sl;
 
@@ -167,17 +167,17 @@ namespace Git
             }
         }
 
-        StrArrayWrapper::~StrArrayWrapper()
+        StrArray::~StrArray()
         {
             delete[] a.strings;
         }
 
-        StrArrayWrapper::operator git_strarray*()
+        StrArray::operator git_strarray*()
         {
             return &a;
         }
 
-        StrArrayWrapper::operator const git_strarray *() const
+        StrArray::operator const git_strarray *() const
         {
             return &a;
         }

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -143,27 +143,16 @@ namespace Git
             Q_ASSERT(false);
         }
 
-        StrArray::StrArray( const StrArray & )
-        {
-            Q_ASSERT(false);
-        }
-
-        StrArray& StrArray::operator=(const StrArray&)
-        {
-            Q_ASSERT(false);
-            return *this;
-        }
 
         StrArray::StrArray(const QStringList& sl)
         {
-            internalCopy = sl;
-
-            a.count = internalCopy.count();
+            a.count = sl.count();
             a.strings = new char *[a.count];
 
-            for(int i=0; i < internalCopy.count(); ++i )
+            for( int i = 0; i < sl.count(); i++ )
             {
-                a.strings[i] = internalCopy[i].toUtf8().data();
+                mEncoded << GW_EncodeQString( sl[i] );
+                a.strings[i] = mEncoded[i].data();
             }
         }
 
@@ -192,14 +181,14 @@ namespace Git
 
         StrArrayRef::StrArrayRef(git_strarray& _a, const QStringList& sl)
             : a(_a)
-            , internalCopy(sl)
         {
-            a.count = internalCopy.count();
+            a.count = sl.count();
             a.strings = new char *[a.count];
 
-            for(int i=0; i < internalCopy.count(); ++i )
+            for(int i=0; i < sl.count(); ++i )
             {
-                a.strings[i] = internalCopy[i].toUtf8().data();
+                mEncoded << GW_EncodeQString( sl[i] );
+                a.strings[i] = mEncoded[i].data();
             }
         }
 

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -83,18 +83,6 @@ namespace Git
             return StringHelper( buf.ptr, buf.size );
         }
 
-        Buffer::Buffer(const Buffer& other)
-        {
-            *this = other;
-        }
-
-        Buffer& Buffer::operator =(const Buffer& other)
-        {
-            memcpy( buf.ptr, other.buf.ptr, other.buf.size );
-            buf.asize = other.buf.asize;
-            return *this;
-        }
-
 
         //-- String ------------------------------------------------------------------------------>8
 

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -182,15 +182,15 @@ namespace Git
             return &a;
         }
 
-        //-- StrArray --------------------------------------------------------------------------- >8
+        //-- StrArrayRef ------------------------------------------------------------------------ >8
 
-        StrArray& StrArray::operator=(const StrArray&)
+        StrArrayRef& StrArrayRef::operator=(const StrArrayRef&)
         {
             Q_ASSERT(false);
             return *this;
         }
 
-        StrArray::StrArray(git_strarray& _a, const QStringList& sl)
+        StrArrayRef::StrArrayRef(git_strarray& _a, const QStringList& sl)
             : a(_a)
             , internalCopy(sl)
         {
@@ -203,7 +203,7 @@ namespace Git
             }
         }
 
-        StrArray::~StrArray()
+        StrArrayRef::~StrArrayRef()
         {
             delete[] a.strings;
         }

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -98,56 +98,36 @@ namespace Git
 
         //-- String ------------------------------------------------------------------------------>8
 
-        String::String(QString str, QTextCodec* codec)
+        String::String(QString str)
             : mStr(str)
-            , mCodec(codec)
         {
         }
 
-        String::String(const char* str, QTextCodec* codec)
-            : mCodec(codec)
+        String::String(const char* str)
         {
-            mStr = convert( str, codec );
+            mStr = convert( str );
         }
 
-        String::String(const char* str, int size, QTextCodec* codec)
+        String::String(const char* str, int size)
         {
-            mStr = convert( str, size, codec );
+            mStr = convert( str, size );
         }
 
-        QString String::convert(const char* str, int size, QTextCodec* codec )
+        QString String::convert(const char* str, int size )
         {
-            return codec ? codec->toUnicode( str, size )
-                         : QString::fromUtf8( str, size );
+            return QString::fromUtf8( str, size );
         }
 
-        QString String::convert(const char* str, QTextCodec* codec )
+        QString String::convert(const char* str)
         {
-            return codec ? codec->toUnicode( str )
-                         : QString::fromUtf8( str );
+            return QString::fromUtf8( str );
         }
 
         const char* String::convert()
         {
             mConvertedStr = toArray();
             return mConvertedStr.constData();
-        }
 
-        QByteArray String::toArray() const
-        {
-            return mCodec ? mCodec->fromUnicode( mStr )
-                          : mStr.toUtf8();
-        }
-
-        String::String(const String& other)
-        {
-            *this = other;
-        }
-
-        String& String::operator =(const String& other)
-        {
-            *this = other;
-            return *this;
         }
 
         String::operator const char*()

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -160,7 +160,7 @@ namespace Git
         }
 
         git_index* index = NULL;
-        result = git_index_open( &index, Internal::StringHelper(path) );
+        result = git_index_open( &index, GW_StringFromQt(path) );
 
         if (!result) {
             return Index();
@@ -251,7 +251,7 @@ namespace Git
     IndexEntry Index::getEntry(Result &result, const QString &path, Stages stage) const
     {
         GW_CD_CHECKED(Index, IndexEntry(), result)
-        const git_index_entry *entry = git_index_get_bypath(d->index, Internal::StringHelper(path),
+        const git_index_entry *entry = git_index_get_bypath(d->index, GW_StringFromQt(path),
                                                             int(stage));
         if(entry == NULL)
         {
@@ -347,7 +347,7 @@ namespace Git
     void Index::addFile(Result &result, const QString &path)
     {
         GW_CD_CHECKED_VOID(Index, result)
-        result = git_index_add_bypath( d->index, Internal::StringHelper(path) );
+        result = git_index_add_bypath( d->index, GW_StringFromQt(path) );
     }
 
     /**
@@ -362,7 +362,7 @@ namespace Git
     void Index::removeFile(Result &result, const QString &path)
     {
         GW_D_CHECKED_VOID(Index, result)
-        result = git_index_remove_bypath( d->index, Internal::StringHelper(path) );
+        result = git_index_remove_bypath( d->index, GW_StringFromQt(path) );
     }
 
     /**

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -160,7 +160,7 @@ namespace Git
         }
 
         git_index* index = NULL;
-        result = git_index_open( &index, path.toUtf8().constData() );
+        result = git_index_open( &index, Internal::String(path) );
 
         if (!result) {
             return Index();
@@ -251,7 +251,7 @@ namespace Git
     IndexEntry Index::getEntry(Result &result, const QString &path, Stages stage) const
     {
         GW_CD_CHECKED(Index, IndexEntry(), result)
-        const git_index_entry *entry = git_index_get_bypath(d->index, path.toUtf8().constData(),
+        const git_index_entry *entry = git_index_get_bypath(d->index, Internal::String(path),
                                                             int(stage));
         if(entry == NULL)
         {
@@ -347,7 +347,7 @@ namespace Git
     void Index::addFile(Result &result, const QString &path)
     {
         GW_CD_CHECKED_VOID(Index, result)
-        result = git_index_add_bypath( d->index, path.toUtf8().constData() );
+        result = git_index_add_bypath( d->index, Internal::String(path) );
     }
 
     /**
@@ -362,7 +362,7 @@ namespace Git
     void Index::removeFile(Result &result, const QString &path)
     {
         GW_D_CHECKED_VOID(Index, result)
-        result = git_index_remove_bypath( d->index, path.toUtf8().constData() );
+        result = git_index_remove_bypath( d->index, Internal::String(path) );
     }
 
     /**

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -160,7 +160,7 @@ namespace Git
         }
 
         git_index* index = NULL;
-        result = git_index_open( &index, Internal::String(path) );
+        result = git_index_open( &index, Internal::StringHelper(path) );
 
         if (!result) {
             return Index();
@@ -251,7 +251,7 @@ namespace Git
     IndexEntry Index::getEntry(Result &result, const QString &path, Stages stage) const
     {
         GW_CD_CHECKED(Index, IndexEntry(), result)
-        const git_index_entry *entry = git_index_get_bypath(d->index, Internal::String(path),
+        const git_index_entry *entry = git_index_get_bypath(d->index, Internal::StringHelper(path),
                                                             int(stage));
         if(entry == NULL)
         {
@@ -347,7 +347,7 @@ namespace Git
     void Index::addFile(Result &result, const QString &path)
     {
         GW_CD_CHECKED_VOID(Index, result)
-        result = git_index_add_bypath( d->index, Internal::String(path) );
+        result = git_index_add_bypath( d->index, Internal::StringHelper(path) );
     }
 
     /**
@@ -362,7 +362,7 @@ namespace Git
     void Index::removeFile(Result &result, const QString &path)
     {
         GW_D_CHECKED_VOID(Index, result)
-        result = git_index_remove_bypath( d->index, Internal::String(path) );
+        result = git_index_remove_bypath( d->index, Internal::StringHelper(path) );
     }
 
     /**

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -403,7 +403,7 @@ namespace Git
         if ( !result )
             return;
 
-        result = git_reset_default( d->repo()->mRepo, o, Internal::StrArrayWrapper( paths ) );
+        result = git_reset_default( d->repo()->mRepo, o, Internal::StrArray( paths ) );
 
         if (result) {
             d->clearKnownConflicts();   // conflicts need to be reloaded as conflicts related to

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -427,7 +427,7 @@ namespace Git
         GW_D_CHECKED_VOID(Index, result)
         git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
         options.checkout_strategy = GIT_CHECKOUT_FORCE;
-        Internal::StrArray(options.paths, paths);
+        Internal::StrArrayRef(options.paths, paths);
 
         result = git_checkout_index(d->repo()->mRepo, d->index, &options);
     }

--- a/libGitWrap/IndexEntry.cpp
+++ b/libGitWrap/IndexEntry.cpp
@@ -53,7 +53,7 @@ namespace Git
     QString IndexEntry::path() const
     {
         GW_CD(IndexEntry);
-        return QString::fromUtf8( d->mEntry.path );
+        return Internal::String( d->mEntry.path );
     }
 
     ObjectId IndexEntry::blobSha() const

--- a/libGitWrap/IndexEntry.cpp
+++ b/libGitWrap/IndexEntry.cpp
@@ -53,7 +53,7 @@ namespace Git
     QString IndexEntry::path() const
     {
         GW_CD(IndexEntry);
-        return Internal::String( d->mEntry.path );
+        return Internal::StringHelper( d->mEntry.path );
     }
 
     ObjectId IndexEntry::blobSha() const

--- a/libGitWrap/IndexEntry.cpp
+++ b/libGitWrap/IndexEntry.cpp
@@ -53,7 +53,7 @@ namespace Git
     QString IndexEntry::path() const
     {
         GW_CD(IndexEntry);
-        return Internal::StringHelper( d->mEntry.path );
+        return GW_StringToQt( d->mEntry.path );
     }
 
     ObjectId IndexEntry::blobSha() const

--- a/libGitWrap/ObjectId.cpp
+++ b/libGitWrap/ObjectId.cpp
@@ -35,7 +35,7 @@ namespace Git
 
     ObjectId ObjectId::fromString( const QString& oid, int max, bool* success )
     {
-        return fromAscii( oid.toUtf8(), max, success );
+        return fromAscii( Internal::String(oid).toArray(), max, success );
     }
 
     ObjectId ObjectId::fromAscii( const QByteArray& oid, int max, bool* success )
@@ -69,7 +69,7 @@ namespace Git
 
     QString ObjectId::toString(int max) const
     {
-        return QString::fromUtf8(toAscii(max).constData()); // UTF-8 is Ascii, actually :-)
+        return Internal::String(toAscii(max).constData()); // UTF-8 is Ascii, actually :-)
     }
 
     QByteArray ObjectId::toAscii(int max) const

--- a/libGitWrap/ObjectId.cpp
+++ b/libGitWrap/ObjectId.cpp
@@ -35,7 +35,7 @@ namespace Git
 
     ObjectId ObjectId::fromString( const QString& oid, int max, bool* success )
     {
-        return fromAscii( Internal::StringHelper(oid).toArray(), max, success );
+        return fromAscii( GW_EncodeQString(oid), max, success );
     }
 
     ObjectId ObjectId::fromAscii( const QByteArray& oid, int max, bool* success )
@@ -69,7 +69,7 @@ namespace Git
 
     QString ObjectId::toString(int max) const
     {
-        return Internal::StringHelper(toAscii(max).constData()); // UTF-8 is Ascii, actually :-)
+        return GW_StringToQt(toAscii(max)); // UTF-8 is Ascii, actually :-)
     }
 
     QByteArray ObjectId::toAscii(int max) const

--- a/libGitWrap/ObjectId.cpp
+++ b/libGitWrap/ObjectId.cpp
@@ -35,7 +35,7 @@ namespace Git
 
     ObjectId ObjectId::fromString( const QString& oid, int max, bool* success )
     {
-        return fromAscii( Internal::String(oid).toArray(), max, success );
+        return fromAscii( Internal::StringHelper(oid).toArray(), max, success );
     }
 
     ObjectId ObjectId::fromAscii( const QByteArray& oid, int max, bool* success )
@@ -69,7 +69,7 @@ namespace Git
 
     QString ObjectId::toString(int max) const
     {
-        return Internal::String(toAscii(max).constData()); // UTF-8 is Ascii, actually :-)
+        return Internal::StringHelper(toAscii(max).constData()); // UTF-8 is Ascii, actually :-)
     }
 
     QByteArray ObjectId::toAscii(int max) const

--- a/libGitWrap/Operations/CheckoutOperation.cpp
+++ b/libGitWrap/Operations/CheckoutOperation.cpp
@@ -38,7 +38,7 @@ namespace Git
                     reinterpret_cast<CheckoutBaseOperationPrivate*>(payload);
             Q_ASSERT(d);
 
-            QString pathName = QString::fromUtf8(path);
+            QString pathName = Internal::String(path);
 
             d->emitProgress(pathName, completed_steps, total_steps);
         }
@@ -82,7 +82,7 @@ namespace Git
                                                     const git_diff_file *workdir)
         {
             GW_OP_OWNER(CheckoutBaseOperation);
-            QString pathName = QString::fromUtf8(path);
+            QString pathName = Internal::String(path);
 
             FileInfo fiBaseLine = mkFileInfo(baseline);
             FileInfo fiTarget   = mkFileInfo(target);
@@ -123,12 +123,12 @@ namespace Git
                 mOpts.paths.count = mPaths.count();
                 mOpts.paths.strings = new char *[mOpts.paths.count];
                 for (int i=0; i < mPaths.count(); ++i) {
-                    mOpts.paths.strings[i] = mPaths[i].toUtf8().data();
+                    mOpts.paths.strings[i] = Internal::String(mPaths[i]);
                 }
             }
 
             if (!mPath.isEmpty()) {
-                mOpts.target_directory = mPath.toUtf8().constData();
+                mOpts.target_directory = Internal::String(mPath);
             }
 
             switch (mMode) {

--- a/libGitWrap/Operations/CheckoutOperation.cpp
+++ b/libGitWrap/Operations/CheckoutOperation.cpp
@@ -38,7 +38,7 @@ namespace Git
                     reinterpret_cast<CheckoutBaseOperationPrivate*>(payload);
             Q_ASSERT(d);
 
-            QString pathName = Internal::String(path);
+            QString pathName = Internal::StringHelper(path);
 
             d->emitProgress(pathName, completed_steps, total_steps);
         }
@@ -82,7 +82,7 @@ namespace Git
                                                     const git_diff_file *workdir)
         {
             GW_OP_OWNER(CheckoutBaseOperation);
-            QString pathName = Internal::String(path);
+            QString pathName = Internal::StringHelper(path);
 
             FileInfo fiBaseLine = mkFileInfo(baseline);
             FileInfo fiTarget   = mkFileInfo(target);
@@ -123,12 +123,12 @@ namespace Git
                 mOpts.paths.count = mPaths.count();
                 mOpts.paths.strings = new char *[mOpts.paths.count];
                 for (int i=0; i < mPaths.count(); ++i) {
-                    mOpts.paths.strings[i] = Internal::String(mPaths[i]);
+                    mOpts.paths.strings[i] = Internal::StringHelper(mPaths[i]);
                 }
             }
 
             if (!mPath.isEmpty()) {
-                mOpts.target_directory = Internal::String(mPath);
+                mOpts.target_directory = Internal::StringHelper(mPath);
             }
 
             switch (mMode) {

--- a/libGitWrap/Operations/CheckoutOperation.cpp
+++ b/libGitWrap/Operations/CheckoutOperation.cpp
@@ -120,11 +120,8 @@ namespace Git
             memcpy(&mOpts, &o, sizeof(o));
 
             if (mPaths.count()) {
-                mOpts.paths.count = mPaths.count();
-                mOpts.paths.strings = new char *[mOpts.paths.count];
-                for (int i=0; i < mPaths.count(); ++i) {
-                    mOpts.paths.strings[i] = Internal::StringHelper(mPaths[i]);
-                }
+                // TODO: Build a suitable wrapper around git_checkout_options, that has a Internal::StrArray member.
+                git_strarray_copy( &mOpts.paths, StrArray( mPaths ) );
             }
 
             if (!mPath.isEmpty()) {
@@ -173,7 +170,7 @@ namespace Git
 
         void CheckoutBaseOperationPrivate::unprepare()
         {
-            delete[] mOpts.paths.strings;
+            git_strarray_free( &mOpts.paths );
         }
 
         // -- CheckoutIndexOperationPrivate ----------------------------------------------------- >8

--- a/libGitWrap/Operations/CheckoutOperation.cpp
+++ b/libGitWrap/Operations/CheckoutOperation.cpp
@@ -38,7 +38,7 @@ namespace Git
                     reinterpret_cast<CheckoutBaseOperationPrivate*>(payload);
             Q_ASSERT(d);
 
-            QString pathName = Internal::StringHelper(path);
+            QString pathName = GW_StringToQt(path);
 
             d->emitProgress(pathName, completed_steps, total_steps);
         }
@@ -82,7 +82,7 @@ namespace Git
                                                     const git_diff_file *workdir)
         {
             GW_OP_OWNER(CheckoutBaseOperation);
-            QString pathName = Internal::StringHelper(path);
+            QString pathName = GW_StringToQt(path);
 
             FileInfo fiBaseLine = mkFileInfo(baseline);
             FileInfo fiTarget   = mkFileInfo(target);
@@ -128,7 +128,7 @@ namespace Git
             }
 
             if (!mPath.isEmpty()) {
-                mOpts.target_directory = Internal::StringHelper(mPath);
+                mOpts.target_directory = GW_StringFromQt(mPath);
             }
 
             switch (mMode) {

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -136,7 +136,7 @@ namespace Git
     {
         GW_D(CloneOperation);
         Q_ASSERT(!isRunning());
-        d->mRemoteName = Internal::String(remoteName).toArray();
+        d->mRemoteName = Internal::StringHelper(remoteName).toArray();
     }
 
     void CloneOperation::setFetchSpec(const QByteArray& fetchSpec)

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -136,7 +136,7 @@ namespace Git
     {
         GW_D(CloneOperation);
         Q_ASSERT(!isRunning());
-        d->mRemoteName = remoteName.toUtf8();
+        d->mRemoteName = Internal::String(remoteName).toArray();
     }
 
     void CloneOperation::setFetchSpec(const QByteArray& fetchSpec)

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -136,7 +136,7 @@ namespace Git
     {
         GW_D(CloneOperation);
         Q_ASSERT(!isRunning());
-        d->mRemoteName = Internal::StringHelper(remoteName).toArray();
+        d->mRemoteName = GW_EncodeQString(remoteName);
     }
 
     void CloneOperation::setFetchSpec(const QByteArray& fetchSpec)

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -86,26 +86,32 @@ namespace Git
         class String
         {
         public:
-            String( const QString& str, QTextCodec* codec = 0 );
+            String( QString str, QTextCodec* codec = 0);
             String( const char* str, QTextCodec* codec = 0 );
             String( const char* str, int size, QTextCodec* codec = 0 );
 
         public:
-            operator const char*() const;
+            operator const char*();
             operator char*();
             operator QString();
+
+        public:
+            static QString convert( const char* str, int size, QTextCodec* codec = 0 );
+            static QString convert( const char* str, QTextCodec* codec = 0 );
+
+        public:
+            QByteArray toArray() const;
+
+        private:
+            const char* convert();
 
         private:
             String(const String& other);
             String& operator =(const String& other);
 
         private:
-            static QString convert( const char* str, int size, QTextCodec* codec = 0 );
-            static QString convert( const char* str, QTextCodec* codec = 0 );
-            static const char* convert( const QString& str, QTextCodec *codec );
-
-        private:
             QString         mStr;
+            QByteArray      mConvertedStr;  //!< the string is converted, using QString's conversion methods
             QTextCodec *    mCodec;
         };
 

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -86,9 +86,9 @@ namespace Git
         class String
         {
         public:
-            String( QString str, QTextCodec* codec = 0);
-            String( const char* str, QTextCodec* codec = 0 );
-            String( const char* str, int size, QTextCodec* codec = 0 );
+            String( QString str );
+            String( const char* str );
+            String( const char* str, int size );
 
         public:
             operator const char*();
@@ -96,8 +96,8 @@ namespace Git
             operator QString();
 
         public:
-            static QString convert( const char* str, int size, QTextCodec* codec = 0 );
-            static QString convert( const char* str, QTextCodec* codec = 0 );
+            static QString convert( const char* str, int size );
+            static QString convert( const char* str );
 
         public:
             QByteArray toArray() const;
@@ -112,7 +112,6 @@ namespace Git
         private:
             QString         mStr;
             QByteArray      mConvertedStr;  //!< the string is converted, using QString's conversion methods
-            QTextCodec *    mCodec;
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -80,47 +80,6 @@ namespace Git
         /**
          * @internal
          * @ingroup     GitWrap
-         * @brief       Wraps a QString for usage in libgit2.
-         *
-         * The QString is encoded to the codec used by libgit2 (in other words UTF-8).
-         */
-        class StringHelper
-        {
-        public:
-            StringHelper( QString str );
-            StringHelper( const char* str );
-            StringHelper( const char* str, int size );
-
-        public:
-            operator const char*() const;
-            operator char*() const;
-            operator QString() const;
-
-        public:
-            static QString convert( const char* str, int size );
-            static QString convert( const char* str );
-
-        public:
-            inline QByteArray toArray() const
-            {
-                return mStr.toUtf8();
-            }
-
-        private:
-            const char* convert() const;
-
-        private:
-            StringHelper(const StringHelper& other);
-            StringHelper& operator =(const StringHelper& other);
-
-        private:
-            QString                 mStr;
-            mutable QByteArray      mConvertedStr;  //!< the string is converted, using QString's conversion methods
-        };
-
-        /**
-         * @internal
-         * @ingroup     GitWrap
          * @brief       Wraps a QStringList as a pointer to git_strarray.
          */
         class StrArray

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -81,14 +81,14 @@ namespace Git
          * @ingroup     GitWrap
          * @brief       Wraps a QString for usage in libgit2.
          *
-         * The QString is encoded to the codec used by libgit2. Defaults to UTF-8.
+         * The QString is encoded to the codec used by libgit2 (in other words UTF-8).
          */
-        class String
+        class StringHelper
         {
         public:
-            String( QString str );
-            String( const char* str );
-            String( const char* str, int size );
+            StringHelper( QString str );
+            StringHelper( const char* str );
+            StringHelper( const char* str, int size );
 
         public:
             operator const char*() const;
@@ -109,8 +109,8 @@ namespace Git
             const char* convert() const;
 
         private:
-            String(const String& other);
-            String& operator =(const String& other);
+            StringHelper(const StringHelper& other);
+            StringHelper& operator =(const StringHelper& other);
 
         private:
             QString                 mStr;

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -120,21 +120,21 @@ namespace Git
         /**
          * @internal
          * @ingroup     GitWrap
-         * @brief       The StrArrayWrapper class wraps a QStringList as a pointer to git_strarray.
+         * @brief       Wraps a QStringList as a pointer to git_strarray.
          */
-        class StrArrayWrapper
+        class StrArray
         {
         public:
-            StrArrayWrapper(const QStringList& sl);
-            ~StrArrayWrapper();
+            StrArray(const QStringList& sl);
+            ~StrArray();
 
             operator git_strarray*();
             operator const git_strarray*() const;
 
         private:
-            StrArrayWrapper();
-            StrArrayWrapper(const StrArrayWrapper&);
-            StrArrayWrapper& operator=(const StrArrayWrapper&);
+            StrArray();
+            StrArray(const StrArray&);
+            StrArray& operator=(const StrArray&);
 
         private:
             git_strarray a;

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -300,16 +300,23 @@ namespace Git
 /**
   * @internal
   * @ingroup GitWrap
+  * @def Encode a QString into a QByteArray with the UTF-8 codec used by libgit2.
+  */
+#define GW_EncodeQString(s) (s).toUtf8()
+
+/**
+  * @internal
+  * @ingroup GitWrap
   * @def Encode a QString with the UTF-8 codec used by libgit2.
   */
-#define GW_StringFromQt(x) (x).toUtf8().constData()
+#define GW_StringFromQt(s) GW_EncodeQString(s).constData()
 
 /**
   * @internal
   * @ingroup GitWrap
   * @def Macro to create a QString from an UTF-8 encoded libgit2 string.
   */
-#define GW_StringToQt(x) QString::fromUtf8(x)
+#define GW_StringToQt(s, ...) QString::fromUtf8(s, ##__VA_ARGS__)
 
 
 // -- pimpl helper macro definitions ->8

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -28,6 +28,7 @@
 #include "libGitWrap/Result.hpp"
 #include "libGitWrap/ObjectId.hpp"
 
+
 namespace Git
 {
 
@@ -291,6 +292,27 @@ namespace Git
     }
 
 }
+
+
+// -- internal macro definitions -->8
+
+// string macro definitions -->8
+/**
+  * @internal
+  * @ingroup GitWrap
+  * @def Encode a QString with the UTF-8 codec used by libgit2.
+  */
+#define GW_StringFromQt(x) (x).toUtf8().constData()
+
+/**
+  * @internal
+  * @ingroup GitWrap
+  * @def Macro to create a QString from an UTF-8 encoded libgit2 string.
+  */
+#define GW_StringToQt(x) QString::fromUtf8(x)
+
+
+// -- pimpl helper macro definitions ->8
 
 #define GW__CHECK(returns, result) \
     if (!Private::isValid(result, d)) { return returns; }

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -139,7 +139,7 @@ namespace Git
 
         private:
             git_strarray a;
-            QStringList internalCopy;
+            QVector<QByteArray>   mEncoded;
         };
 
         class StrArrayRef
@@ -154,7 +154,7 @@ namespace Git
 
         private:
             git_strarray& a;
-            QStringList internalCopy;
+            QVector<QByteArray> mEncoded;
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -100,7 +100,10 @@ namespace Git
             static QString convert( const char* str );
 
         public:
-            QByteArray toArray() const;
+            inline QByteArray toArray() const
+            {
+                return mStr.toUtf8();
+            }
 
         private:
             const char* convert();

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -141,15 +141,15 @@ namespace Git
             QStringList internalCopy;
         };
 
-        class StrArray
+        class StrArrayRef
         {
         public:
-            StrArray(git_strarray& _a, const QStringList& sl);
-            ~StrArray();
+            StrArrayRef(git_strarray& _a, const QStringList& sl);
+            ~StrArrayRef();
 
         private:
             /* Cannot privatize Copy+Default ctor because of the member-by-reference */
-            StrArray& operator=(const StrArray&);
+            StrArrayRef& operator=(const StrArrayRef&);
 
         private:
             git_strarray& a;

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -91,9 +91,9 @@ namespace Git
             String( const char* str, int size );
 
         public:
-            operator const char*();
-            operator char*();
-            operator QString();
+            operator const char*() const;
+            operator char*() const;
+            operator QString() const;
 
         public:
             static QString convert( const char* str, int size );
@@ -106,15 +106,15 @@ namespace Git
             }
 
         private:
-            const char* convert();
+            const char* convert() const;
 
         private:
             String(const String& other);
             String& operator =(const String& other);
 
         private:
-            QString         mStr;
-            QByteArray      mConvertedStr;  //!< the string is converted, using QString's conversion methods
+            QString                 mStr;
+            mutable QByteArray      mConvertedStr;  //!< the string is converted, using QString's conversion methods
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -79,6 +79,39 @@ namespace Git
         /**
          * @internal
          * @ingroup     GitWrap
+         * @brief       Wraps a QString for usage in libgit2.
+         *
+         * The QString is encoded to the codec used by libgit2. Defaults to UTF-8.
+         */
+        class String
+        {
+        public:
+            String( const QString& str, QTextCodec* codec = 0 );
+            String( const char* str, QTextCodec* codec = 0 );
+            String( const char* str, int size, QTextCodec* codec = 0 );
+
+        public:
+            operator const char*() const;
+            operator char*();
+            operator QString();
+
+        private:
+            String(const String& other);
+            String& operator =(const String& other);
+
+        private:
+            static QString convert( const char* str, int size, QTextCodec* codec = 0 );
+            static QString convert( const char* str, QTextCodec* codec = 0 );
+            static const char* convert( const QString& str, QTextCodec *codec );
+
+        private:
+            QString         mStr;
+            QTextCodec *    mCodec;
+        };
+
+        /**
+         * @internal
+         * @ingroup     GitWrap
          * @brief       The StrArrayWrapper class wraps a QStringList as a pointer to git_strarray.
          */
         class StrArrayWrapper

--- a/libGitWrap/RefName.cpp
+++ b/libGitWrap/RefName.cpp
@@ -413,7 +413,7 @@ namespace Git
                                                           const QString& name, git_reference* lgo)
         {
             if (!lgo) {
-                if (git_reference_lookup(&lgo, repo->mRepo, name.toUtf8().constData()) < 0) {
+                if (git_reference_lookup(&lgo, repo->mRepo, Internal::String(name)) < 0) {
                     return NULL;
                 }
             }

--- a/libGitWrap/RefName.cpp
+++ b/libGitWrap/RefName.cpp
@@ -413,7 +413,7 @@ namespace Git
                                                           const QString& name, git_reference* lgo)
         {
             if (!lgo) {
-                if (git_reference_lookup(&lgo, repo->mRepo, Internal::String(name)) < 0) {
+                if (git_reference_lookup(&lgo, repo->mRepo, Internal::StringHelper(name)) < 0) {
                     return NULL;
                 }
             }

--- a/libGitWrap/RefName.cpp
+++ b/libGitWrap/RefName.cpp
@@ -413,7 +413,7 @@ namespace Git
                                                           const QString& name, git_reference* lgo)
         {
             if (!lgo) {
-                if (git_reference_lookup(&lgo, repo->mRepo, Internal::StringHelper(name)) < 0) {
+                if (git_reference_lookup(&lgo, repo->mRepo, GW_StringFromQt(name)) < 0) {
                     return NULL;
                 }
             }

--- a/libGitWrap/RefSpec.cpp
+++ b/libGitWrap/RefSpec.cpp
@@ -31,8 +31,8 @@ namespace Git
                 return RefSpec();
             }
 
-            QString src = Internal::StringHelper::convert( git_refspec_src( refspec ) );
-            QString dst = Internal::StringHelper::convert( git_refspec_dst( refspec ) );
+            QString src = GW_StringToQt( git_refspec_src( refspec ) );
+            QString dst = GW_StringToQt( git_refspec_dst( refspec ) );
             return RefSpec( src, dst );
         }
 

--- a/libGitWrap/RefSpec.cpp
+++ b/libGitWrap/RefSpec.cpp
@@ -31,8 +31,8 @@ namespace Git
                 return RefSpec();
             }
 
-            QString src = QString::fromUtf8( git_refspec_src( refspec ) );
-            QString dst = QString::fromUtf8( git_refspec_dst( refspec ) );
+            QString src = Internal::String::convert( git_refspec_src( refspec ) );
+            QString dst = Internal::String::convert( git_refspec_dst( refspec ) );
             return RefSpec( src, dst );
         }
 

--- a/libGitWrap/RefSpec.cpp
+++ b/libGitWrap/RefSpec.cpp
@@ -31,8 +31,8 @@ namespace Git
                 return RefSpec();
             }
 
-            QString src = Internal::String::convert( git_refspec_src( refspec ) );
-            QString dst = Internal::String::convert( git_refspec_dst( refspec ) );
+            QString src = Internal::StringHelper::convert( git_refspec_src( refspec ) );
+            QString dst = Internal::StringHelper::convert( git_refspec_dst( refspec ) );
             return RefSpec( src, dst );
         }
 

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -54,7 +54,7 @@ namespace Git
             , reference(ref)
         {
             Q_ASSERT(reference);
-            fqrn = Internal::StringHelper::convert(git_reference_name(reference));
+            fqrn = GW_StringToQt(git_reference_name(reference));
         }
 
         ReferencePrivate::ReferencePrivate(const RepositoryPrivate::Ptr& repo, const QString& name,
@@ -183,7 +183,7 @@ namespace Git
         Repository::Private* repop = Private::dataOf<Repository>(repo);
 
         git_reference* ref = NULL;
-        QByteArray utf8Name = Internal::StringHelper(name).toArray();
+        QByteArray utf8Name = GW_EncodeQString(name);
 
         result = git_reference_create(
                     &ref,
@@ -280,7 +280,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper(git_reference_shorthand(d->reference));
+        return GW_StringToQt(git_reference_shorthand(d->reference));
     }
 
     ReferenceTypes Reference::type() const
@@ -323,7 +323,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper(git_reference_symbolic_target(d->reference));
+        return GW_StringToQt(git_reference_symbolic_target(d->reference));
     }
 
     Reference Reference::resolved( Result& result ) const

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -54,7 +54,7 @@ namespace Git
             , reference(ref)
         {
             Q_ASSERT(reference);
-            fqrn = Internal::String::convert(git_reference_name(reference));
+            fqrn = Internal::StringHelper::convert(git_reference_name(reference));
         }
 
         ReferencePrivate::ReferencePrivate(const RepositoryPrivate::Ptr& repo, const QString& name,
@@ -183,7 +183,7 @@ namespace Git
         Repository::Private* repop = Private::dataOf<Repository>(repo);
 
         git_reference* ref = NULL;
-        QByteArray utf8Name = Internal::String(name).toArray();
+        QByteArray utf8Name = Internal::StringHelper(name).toArray();
 
         result = git_reference_create(
                     &ref,
@@ -280,7 +280,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String(git_reference_shorthand(d->reference));
+        return Internal::StringHelper(git_reference_shorthand(d->reference));
     }
 
     ReferenceTypes Reference::type() const
@@ -323,7 +323,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String(git_reference_symbolic_target(d->reference));
+        return Internal::StringHelper(git_reference_symbolic_target(d->reference));
     }
 
     Reference Reference::resolved( Result& result ) const

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -54,7 +54,7 @@ namespace Git
             , reference(ref)
         {
             Q_ASSERT(reference);
-            fqrn = QString::fromUtf8(git_reference_name(reference));
+            fqrn = Internal::String::convert(git_reference_name(reference));
         }
 
         ReferencePrivate::ReferencePrivate(const RepositoryPrivate::Ptr& repo, const QString& name,
@@ -183,7 +183,7 @@ namespace Git
         Repository::Private* repop = Private::dataOf<Repository>(repo);
 
         git_reference* ref = NULL;
-        QByteArray utf8Name = name.toUtf8();
+        QByteArray utf8Name = Internal::String(name).toArray();
 
         result = git_reference_create(
                     &ref,
@@ -280,7 +280,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8(git_reference_shorthand(d->reference));
+        return Internal::String(git_reference_shorthand(d->reference));
     }
 
     ReferenceTypes Reference::type() const
@@ -323,7 +323,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8(git_reference_symbolic_target(d->reference));
+        return Internal::String(git_reference_symbolic_target(d->reference));
     }
 
     Reference Reference::resolved( Result& result ) const

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -163,14 +163,13 @@ namespace Git
 
     bool Remote::isValidUrl( const QString& url )
     {
-        return git_remote_valid_url( url.toUtf8().constData() );
+        return isSupportedUrl( url );
     }
 
     bool Remote::isSupportedUrl( const QString& url )
     {
         return git_remote_supported_url( url.toUtf8().constData() );
     }
-
 
     bool Remote::connect(Result& result, bool forFetch)
     {

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -92,7 +92,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8( git_remote_name( d->mRemote ) );
+        return Internal::String( git_remote_name( d->mRemote ) );
     }
 
     QString Remote::url() const
@@ -104,7 +104,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8( git_remote_url( d->mRemote ) );
+        return Internal::String( git_remote_url( d->mRemote ) );
     }
 
     bool Remote::addFetchSpec(Result& result, const QString& spec)

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -92,7 +92,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String( git_remote_name( d->mRemote ) );
+        return Internal::StringHelper( git_remote_name( d->mRemote ) );
     }
 
     QString Remote::url() const
@@ -104,7 +104,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String( git_remote_url( d->mRemote ) );
+        return Internal::StringHelper( git_remote_url( d->mRemote ) );
     }
 
     bool Remote::addFetchSpec(Result& result, const QString& spec)

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -92,7 +92,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper( git_remote_name( d->mRemote ) );
+        return GW_StringToQt( git_remote_name( d->mRemote ) );
     }
 
     QString Remote::url() const
@@ -104,7 +104,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper( git_remote_url( d->mRemote ) );
+        return GW_StringToQt( git_remote_url( d->mRemote ) );
     }
 
     bool Remote::addFetchSpec(Result& result, const QString& spec)

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -62,7 +62,7 @@ namespace Git
         QVector<RefSpec> fetchSpecs() const;
         QVector<RefSpec> pushSpecs() const;
 
-        static bool isValidUrl(const QString& url);
+        GW_DEPRECATED static bool isValidUrl(const QString& url);
         static bool isSupportedUrl(const QString& url);
 
         bool connect(Result& result, bool forFetch);

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -91,7 +91,7 @@ namespace Git
             #endif
 
             Git::StatusHash* sh = (Git::StatusHash*) rawSH;
-            sh->insert( Internal::String( fn ), convertFileStatus( status ) );
+            sh->insert( Internal::StringHelper( fn ), convertFileStatus( status ) );
 
             return GIT_OK;
         }
@@ -106,7 +106,7 @@ namespace Git
         {
             cb_append_reference_data *data = (cb_append_reference_data *)payload;
 
-            QString name = Internal::String::convert(git_reference_name(reference));
+            QString name = Internal::StringHelper::convert(git_reference_name(reference));
             Reference::Private* ref = Reference::Private::createRefObject(
                         data->ptr, name, reference);
 
@@ -203,7 +203,7 @@ namespace Git
 
         QString resultPath;
         if ( result )
-            resultPath = Internal::String::convert(repoPath.ptr);
+            resultPath = Internal::StringHelper::convert(repoPath.ptr);
 
         git_buf_free( &repoPath );
 
@@ -438,7 +438,7 @@ namespace Git
                 return -1;
             }
 
-            d->refs.insert( Internal::String( refName ), ObjectId::fromRaw( oid.id ) );
+            d->refs.insert( Internal::StringHelper( refName ), ObjectId::fromRaw( oid.id ) );
 
             return 0;
         }
@@ -509,7 +509,7 @@ namespace Git
         while ((err = git_branch_next(&ref, &type, it)) == GITERR_NONE) {
             Q_ASSERT(ref);
 
-            QString name = Internal::String::convert(git_reference_shorthand(ref));
+            QString name = Internal::StringHelper::convert(git_reference_shorthand(ref));
             sl << name;
 
             git_reference_free(ref);
@@ -582,7 +582,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String( git_repository_workdir( d->mRepo ) );
+        return Internal::StringHelper( git_repository_workdir( d->mRepo ) );
     }
 
     QString Repository::gitPath() const
@@ -594,7 +594,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String( git_repository_path( d->mRepo ) );
+        return Internal::StringHelper( git_repository_path( d->mRepo ) );
     }
 
     /**
@@ -870,7 +870,7 @@ namespace Git
             Q_ASSERT(d && name);
 
             Repository::PrivatePtr repo(d->repo);
-            d->subs.append(new SubmodulePrivate(repo, Internal::String(name)));
+            d->subs.append(new SubmodulePrivate(repo, Internal::StringHelper(name)));
             return 0;
         }
 
@@ -878,7 +878,7 @@ namespace Git
         {
             QStringList* sl = static_cast<QStringList*>(payload);
             Q_ASSERT(sl && name);
-            sl->append(Internal::String(name));
+            sl->append(Internal::StringHelper(name));
             return 0;
         }
 
@@ -1076,7 +1076,7 @@ namespace Git
                 return Reference();
             }
 
-            name = Internal::String::convert(git_reference_name(ref));
+            name = Internal::StringHelper::convert(git_reference_name(ref));
         }
         else {
             result = git_reference_lookup( &ref, d->mRepo, refName.toUtf8().constData() );

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -91,7 +91,7 @@ namespace Git
             #endif
 
             Git::StatusHash* sh = (Git::StatusHash*) rawSH;
-            sh->insert( Internal::StringHelper( fn ), convertFileStatus( status ) );
+            sh->insert( GW_StringToQt( fn ), convertFileStatus( status ) );
 
             return GIT_OK;
         }
@@ -106,7 +106,7 @@ namespace Git
         {
             cb_append_reference_data *data = (cb_append_reference_data *)payload;
 
-            QString name = Internal::StringHelper::convert(git_reference_name(reference));
+            QString name = GW_StringToQt(git_reference_name(reference));
             Reference::Private* ref = Reference::Private::createRefObject(
                         data->ptr, name, reference);
 
@@ -203,7 +203,7 @@ namespace Git
 
         QString resultPath;
         if ( result )
-            resultPath = Internal::StringHelper::convert(repoPath.ptr);
+            resultPath = GW_StringToQt(repoPath.ptr);
 
         git_buf_free( &repoPath );
 
@@ -438,7 +438,7 @@ namespace Git
                 return -1;
             }
 
-            d->refs.insert( Internal::StringHelper( refName ), ObjectId::fromRaw( oid.id ) );
+            d->refs.insert( GW_StringToQt( refName ), ObjectId::fromRaw( oid.id ) );
 
             return 0;
         }
@@ -509,7 +509,7 @@ namespace Git
         while ((err = git_branch_next(&ref, &type, it)) == GITERR_NONE) {
             Q_ASSERT(ref);
 
-            QString name = Internal::StringHelper::convert(git_reference_shorthand(ref));
+            QString name = GW_StringToQt(git_reference_shorthand(ref));
             sl << name;
 
             git_reference_free(ref);
@@ -582,7 +582,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper( git_repository_workdir( d->mRepo ) );
+        return GW_StringToQt( git_repository_workdir( d->mRepo ) );
     }
 
     QString Repository::gitPath() const
@@ -594,7 +594,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper( git_repository_path( d->mRepo ) );
+        return GW_StringToQt( git_repository_path( d->mRepo ) );
     }
 
     /**
@@ -870,7 +870,7 @@ namespace Git
             Q_ASSERT(d && name);
 
             Repository::PrivatePtr repo(d->repo);
-            d->subs.append(new SubmodulePrivate(repo, Internal::StringHelper(name)));
+            d->subs.append(new SubmodulePrivate(repo, GW_StringToQt(name)));
             return 0;
         }
 
@@ -878,7 +878,7 @@ namespace Git
         {
             QStringList* sl = static_cast<QStringList*>(payload);
             Q_ASSERT(sl && name);
-            sl->append(Internal::StringHelper(name));
+            sl->append(GW_StringToQt(name));
             return 0;
         }
 
@@ -1076,7 +1076,7 @@ namespace Git
                 return Reference();
             }
 
-            name = Internal::StringHelper::convert(git_reference_name(ref));
+            name = GW_StringToQt(git_reference_name(ref));
         }
         else {
             result = git_reference_lookup( &ref, d->mRepo, refName.toUtf8().constData() );

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -91,7 +91,7 @@ namespace Git
             #endif
 
             Git::StatusHash* sh = (Git::StatusHash*) rawSH;
-            sh->insert( QString::fromUtf8( fn ), convertFileStatus( status ) );
+            sh->insert( Internal::String( fn ), convertFileStatus( status ) );
 
             return GIT_OK;
         }
@@ -106,7 +106,7 @@ namespace Git
         {
             cb_append_reference_data *data = (cb_append_reference_data *)payload;
 
-            QString name = QString::fromUtf8(git_reference_name(reference));
+            QString name = Internal::String::convert(git_reference_name(reference));
             Reference::Private* ref = Reference::Private::createRefObject(
                         data->ptr, name, reference);
 
@@ -203,7 +203,7 @@ namespace Git
 
         QString resultPath;
         if ( result )
-            resultPath = QString::fromUtf8(repoPath.ptr);
+            resultPath = Internal::String::convert(repoPath.ptr);
 
         git_buf_free( &repoPath );
 
@@ -438,7 +438,7 @@ namespace Git
                 return -1;
             }
 
-            d->refs.insert( QString::fromUtf8( refName ), ObjectId::fromRaw( oid.id ) );
+            d->refs.insert( Internal::String( refName ), ObjectId::fromRaw( oid.id ) );
 
             return 0;
         }
@@ -509,7 +509,7 @@ namespace Git
         while ((err = git_branch_next(&ref, &type, it)) == GITERR_NONE) {
             Q_ASSERT(ref);
 
-            QString name = QString::fromUtf8(git_reference_shorthand(ref));
+            QString name = Internal::String::convert(git_reference_shorthand(ref));
             sl << name;
 
             git_reference_free(ref);
@@ -582,7 +582,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8( git_repository_workdir( d->mRepo ) );
+        return Internal::String( git_repository_workdir( d->mRepo ) );
     }
 
     QString Repository::gitPath() const
@@ -594,7 +594,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8( git_repository_path( d->mRepo ) );
+        return Internal::String( git_repository_path( d->mRepo ) );
     }
 
     /**
@@ -870,7 +870,7 @@ namespace Git
             Q_ASSERT(d && name);
 
             Repository::PrivatePtr repo(d->repo);
-            d->subs.append(new SubmodulePrivate(repo, QString::fromUtf8(name)));
+            d->subs.append(new SubmodulePrivate(repo, Internal::String(name)));
             return 0;
         }
 
@@ -878,7 +878,7 @@ namespace Git
         {
             QStringList* sl = static_cast<QStringList*>(payload);
             Q_ASSERT(sl && name);
-            sl->append(QString::fromUtf8(name));
+            sl->append(Internal::String(name));
             return 0;
         }
 
@@ -1076,7 +1076,7 @@ namespace Git
                 return Reference();
             }
 
-            name = QString::fromUtf8(git_reference_name(ref));
+            name = Internal::String::convert(git_reference_name(ref));
         }
         else {
             result = git_reference_lookup( &ref, d->mRepo, refName.toUtf8().constData() );

--- a/libGitWrap/Result.cpp
+++ b/libGitWrap/Result.cpp
@@ -55,7 +55,7 @@ namespace Git
             if( err )
             {
                 mClass = err->klass;
-                mText = Internal::StringHelper::convert( err->message );
+                mText = GW_StringToQt( err->message );
             }
             else
             {
@@ -81,7 +81,7 @@ namespace Git
     {
         mClass = -1;
         mCode = code;
-        mText = Internal::StringHelper::convert(szErrorText);
+        mText = GW_StringToQt(szErrorText);
     }
 
     /**

--- a/libGitWrap/Result.cpp
+++ b/libGitWrap/Result.cpp
@@ -55,7 +55,7 @@ namespace Git
             if( err )
             {
                 mClass = err->klass;
-                mText = Internal::String::convert( err->message );
+                mText = Internal::StringHelper::convert( err->message );
             }
             else
             {
@@ -81,7 +81,7 @@ namespace Git
     {
         mClass = -1;
         mCode = code;
-        mText = Internal::String::convert(szErrorText);
+        mText = Internal::StringHelper::convert(szErrorText);
     }
 
     /**

--- a/libGitWrap/Result.cpp
+++ b/libGitWrap/Result.cpp
@@ -55,7 +55,7 @@ namespace Git
             if( err )
             {
                 mClass = err->klass;
-                mText = QString::fromUtf8( err->message );
+                mText = Internal::String::convert( err->message );
             }
             else
             {
@@ -81,7 +81,7 @@ namespace Git
     {
         mClass = -1;
         mCode = code;
-        mText = QString::fromUtf8(szErrorText);
+        mText = Internal::String::convert(szErrorText);
     }
 
     /**

--- a/libGitWrap/Signature.cpp
+++ b/libGitWrap/Signature.cpp
@@ -31,8 +31,8 @@ namespace Git
             dt.setUtcOffset( gitsig->when.offset * 60 );
 
             return Signature(
-                Internal::String( gitsig->name ),
-                Internal::String( gitsig->email ),
+                Internal::StringHelper( gitsig->name ),
+                Internal::StringHelper( gitsig->email ),
                 dt );
         }
 

--- a/libGitWrap/Signature.cpp
+++ b/libGitWrap/Signature.cpp
@@ -31,8 +31,8 @@ namespace Git
             dt.setUtcOffset( gitsig->when.offset * 60 );
 
             return Signature(
-                QString::fromUtf8( gitsig->name ),
-                QString::fromUtf8( gitsig->email ),
+                Internal::String( gitsig->name ),
+                Internal::String( gitsig->email ),
                 dt );
         }
 

--- a/libGitWrap/Signature.cpp
+++ b/libGitWrap/Signature.cpp
@@ -31,8 +31,8 @@ namespace Git
             dt.setUtcOffset( gitsig->when.offset * 60 );
 
             return Signature(
-                Internal::StringHelper( gitsig->name ),
-                Internal::StringHelper( gitsig->email ),
+                GW_StringToQt( gitsig->name ),
+                GW_StringToQt( gitsig->email ),
                 dt );
         }
 

--- a/libGitWrap/Submodule.cpp
+++ b/libGitWrap/Submodule.cpp
@@ -125,7 +125,7 @@ namespace Git
         }
 
         const char* data = git_submodule_path( sm );
-        return data ? Internal::StringHelper::convert( data ) : QString();
+        return data ? GW_StringToQt( data ) : QString();
     }
 
     QString Submodule::url( Result& r ) const
@@ -139,7 +139,7 @@ namespace Git
         }
 
         const char* data = git_submodule_url( sm );
-        return data ? Internal::StringHelper::convert( data ) : QString();
+        return data ? GW_StringToQt( data ) : QString();
     }
 
     bool Submodule::fetchRecursive() const

--- a/libGitWrap/Submodule.cpp
+++ b/libGitWrap/Submodule.cpp
@@ -125,7 +125,7 @@ namespace Git
         }
 
         const char* data = git_submodule_path( sm );
-        return data ? Internal::String::convert( data ) : QString();
+        return data ? Internal::StringHelper::convert( data ) : QString();
     }
 
     QString Submodule::url( Result& r ) const
@@ -139,7 +139,7 @@ namespace Git
         }
 
         const char* data = git_submodule_url( sm );
-        return data ? Internal::String::convert( data ) : QString();
+        return data ? Internal::StringHelper::convert( data ) : QString();
     }
 
     bool Submodule::fetchRecursive() const

--- a/libGitWrap/Submodule.cpp
+++ b/libGitWrap/Submodule.cpp
@@ -125,7 +125,7 @@ namespace Git
         }
 
         const char* data = git_submodule_path( sm );
-        return data ? QString::fromUtf8( data ) : QString();
+        return data ? Internal::String::convert( data ) : QString();
     }
 
     QString Submodule::url( Result& r ) const
@@ -139,7 +139,7 @@ namespace Git
         }
 
         const char* data = git_submodule_url( sm );
-        return data ? QString::fromUtf8( data ) : QString();
+        return data ? Internal::String::convert( data ) : QString();
     }
 
     bool Submodule::fetchRecursive() const

--- a/libGitWrap/Tree.cpp
+++ b/libGitWrap/Tree.cpp
@@ -157,7 +157,7 @@ namespace Git
 
         git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
         opts.checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
-        Internal::StrArray(opts.paths, paths);
+        Internal::StrArrayRef(opts.paths, paths);
 
         result = git_checkout_tree(d->repo()->mRepo, d->mObj, &opts);
     }

--- a/libGitWrap/TreeEntry.cpp
+++ b/libGitWrap/TreeEntry.cpp
@@ -87,7 +87,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::String(szName);
+        return Internal::StringHelper(szName);
     }
 
     ObjectType TreeEntry::type() const

--- a/libGitWrap/TreeEntry.cpp
+++ b/libGitWrap/TreeEntry.cpp
@@ -87,7 +87,7 @@ namespace Git
             return QString();
         }
 
-        return QString::fromUtf8(szName);
+        return Internal::String(szName);
     }
 
     ObjectType TreeEntry::type() const

--- a/libGitWrap/TreeEntry.cpp
+++ b/libGitWrap/TreeEntry.cpp
@@ -87,7 +87,7 @@ namespace Git
             return QString();
         }
 
-        return Internal::StringHelper(szName);
+        return GW_StringToQt(szName);
     }
 
     ObjectType TreeEntry::type() const


### PR DESCRIPTION
Introducing `Git::Internal::String` wrapper class to simplify conversion from and to QString.
- Should it be exported to the public interface? If so, the GitWrap API should change to take this class instead of a QString.
