### PR TITLE
follow lg2 master

### DIFF
--- a/libGitWrap/Base.cpp
+++ b/libGitWrap/Base.cpp
@@ -110,8 +110,8 @@ namespace Git
     }
 
     Base::Base(const Base& other)
-        : mData(other.mData)
     {
+        *this = other;
     }
 
     Base::~Base()
@@ -121,7 +121,7 @@ namespace Git
     Base& Base::operator=(const Base& other)
     {
         mData = other.mData;
-        return * this;
+        return *this;
     }
 
     bool Base::operator==(const Base& other) const

--- a/libGitWrap/Base.cpp
+++ b/libGitWrap/Base.cpp
@@ -110,8 +110,8 @@ namespace Git
     }
 
     Base::Base(const Base& other)
+        : mData(other.mData)
     {
-        *this = other;
     }
 
     Base::~Base()
@@ -121,7 +121,7 @@ namespace Git
     Base& Base::operator=(const Base& other)
     {
         mData = other.mData;
-        return *this;
+        return * this;
     }
 
     bool Base::operator==(const Base& other) const

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -178,28 +178,27 @@ namespace Git
 
     GW_PRIVATE_IMPL(DiffList, RepoObject)
 
-    bool DiffList::mergeOnto(Result& result, const DiffList& onto) const
+    void DiffList::mergeOnto(Result& result, const DiffList& onto) const
     {
-        GW_CD_CHECKED(DiffList, false, result)
+        GW_CD_CHECKED_VOID(DiffList, result)
 
         if (!onto.isValid())
         {
             result.setInvalidObject();
-            return false;
+            return;
         }
 
         DiffList::Private* ontoP = Private::dataOf<DiffList>(onto);
         result = git_diff_merge(ontoP->mDiff, d->mDiff);
-        return result;
     }
 
-    bool DiffList::consumePatch(Result& result, PatchConsumer* consumer) const
+    void DiffList::consumePatch(Result& result, PatchConsumer* consumer) const
     {
-        GW_CD_CHECKED(DiffList, false, result)
+        GW_CD_CHECKED_VOID(DiffList, result)
 
         if (!consumer) {
             result.setInvalidObject();
-            return false;
+            return;
         }
 
         result = git_diff_foreach(d->mDiff,
@@ -207,17 +206,15 @@ namespace Git
                                   &Internal::patchHunkCallBack,
                                   &Internal::patchDataCallBack,
                                   consumer );
-
-        return result;
     }
 
-    bool DiffList::consumeChangeList(Result& result, ChangeListConsumer* consumer) const
+    void DiffList::consumeChangeList(Result& result, ChangeListConsumer* consumer) const
     {
-        GW_CD_CHECKED(DiffList, false, result)
+        GW_CD_CHECKED_VOID(DiffList, result)
 
         if (!consumer) {
             result.setInvalidObject();
-            return false;
+            return;
         }
 
         result = git_diff_foreach(d->mDiff,
@@ -225,8 +222,6 @@ namespace Git
                                   NULL,
                                   NULL,
                                   consumer );
-
-        return result;
     }
 
     ChangeList DiffList::changeList(Result &result) const

--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -178,7 +178,7 @@ namespace Git
 
     GW_PRIVATE_IMPL(DiffList, RepoObject)
 
-    bool DiffList::mergeOnto(Result& result, DiffList onto) const
+    bool DiffList::mergeOnto(Result& result, const DiffList& onto) const
     {
         GW_CD_CHECKED(DiffList, false, result)
 

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -34,10 +34,10 @@ namespace Git
      */
     class GITWRAP_API DiffList : public RepoObject
     {
-        GW_PRIVATE_DECL(DiffList, RepoObject, public);
+        GW_PRIVATE_DECL(DiffList, RepoObject, public)
 
     public:
-        bool mergeOnto( Result& result, DiffList other ) const;
+        bool mergeOnto( Result& result, const DiffList& other ) const;
 
         bool consumePatch( Result& result, PatchConsumer* consumer ) const;
         bool consumeChangeList( Result& result,

--- a/libGitWrap/DiffList.hpp
+++ b/libGitWrap/DiffList.hpp
@@ -37,10 +37,10 @@ namespace Git
         GW_PRIVATE_DECL(DiffList, RepoObject, public)
 
     public:
-        bool mergeOnto( Result& result, const DiffList& other ) const;
+        void mergeOnto( Result& result, const DiffList& other ) const;
 
-        bool consumePatch( Result& result, PatchConsumer* consumer ) const;
-        bool consumeChangeList( Result& result,
+        void consumePatch( Result& result, PatchConsumer* consumer ) const;
+        void consumeChangeList( Result& result,
                                 ChangeListConsumer* consumer ) const;
 
         ChangeList changeList(Result& result) const;

--- a/libGitWrap/Events/Private/RemoteCallbacks.cpp
+++ b/libGitWrap/Events/Private/RemoteCallbacks.cpp
@@ -145,19 +145,13 @@ namespace Git
 
         void RemoteCallbacks::initCallbacks(git_remote_callbacks& cb, IRemoteEvents* receiver)
         {
-            git_remote_callbacks cbs = GIT_REMOTE_CALLBACKS_INIT;
+            git_remote_init_callbacks( &cb, GIT_REMOTE_CALLBACKS_VERSION );
 
-            cbs.sideband_progress   = &RemoteCallbacks::remoteProgress;
-            cbs.completion          = &RemoteCallbacks::remoteComplete;
-            cbs.update_tips         = &RemoteCallbacks::remoteUpdateTips;
-            cbs.credentials         = &RemoteCallbacks::credAccquire;
-            cbs.payload             = receiver;
-
-            // We still have to memcpy, because LibGit2-devs hate C++ and disallow us to do a nice
-            // assignment (`mRemoteCallBacks = GIT_REMOTE_CALLBACKS_INIT;`) without using C++11 in
-            // the first place...
-            // So we can as well memcpy the fully initialized variable
-            memcpy(&cb, &cbs, sizeof(cbs));
+            cb.sideband_progress   = &RemoteCallbacks::remoteProgress;
+            cb.completion          = &RemoteCallbacks::remoteComplete;
+            cb.update_tips         = &RemoteCallbacks::remoteUpdateTips;
+            cb.credentials         = &RemoteCallbacks::credAccquire;
+            cb.payload             = receiver;
         }
 
     }

--- a/libGitWrap/Events/Private/RemoteCallbacks.cpp
+++ b/libGitWrap/Events/Private/RemoteCallbacks.cpp
@@ -148,9 +148,11 @@ namespace Git
             git_remote_init_callbacks( &cb, GIT_REMOTE_CALLBACKS_VERSION );
 
             cb.sideband_progress   = &RemoteCallbacks::remoteProgress;
+            cb.transfer_progress   = &RemoteCallbacks::fetchProgress;
             cb.completion          = &RemoteCallbacks::remoteComplete;
             cb.update_tips         = &RemoteCallbacks::remoteUpdateTips;
             cb.credentials         = &RemoteCallbacks::credAccquire;
+
             cb.payload             = receiver;
         }
 

--- a/libGitWrap/Events/Private/RemoteCallbacks.cpp
+++ b/libGitWrap/Events/Private/RemoteCallbacks.cpp
@@ -145,7 +145,10 @@ namespace Git
 
         void RemoteCallbacks::initCallbacks(git_remote_callbacks& cb, IRemoteEvents* receiver)
         {
-            git_remote_init_callbacks( &cb, GIT_REMOTE_CALLBACKS_VERSION );
+            Result r;
+            r = git_remote_init_callbacks( &cb, GIT_REMOTE_CALLBACKS_VERSION );
+            Q_ASSERT_X( r, "git_remote_init_callbacks", qPrintable(r.errorText()) );
+            GW_CHECK_RESULT( r, void() )
 
             cb.sideband_progress   = &RemoteCallbacks::remoteProgress;
             cb.transfer_progress   = &RemoteCallbacks::fetchProgress;

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -114,7 +114,7 @@ namespace Git
             return mOptions;
         }
 
-        const QStringList& CheckoutOptions::paths() const
+        QStringList CheckoutOptions::paths() const
         {
             return mPaths;
         }

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -86,10 +86,46 @@ namespace Git
         }
 
 
-        //-- StrArray --------------------------------------------------------------------------- >8
+        //-- CheckoutOptions -------------------------------------------------------------------- >8
 
+        CheckoutOptions::CheckoutOptions()
         {
+            git_checkout_init_options( &mOptions, GIT_CHECKOUT_OPTIONS_VERSION );
+            mOptions.paths = *mPaths;
         }
+
+        CheckoutOptions::operator git_checkout_options*()
+        {
+            return &mOptions;
+        }
+
+        CheckoutOptions::operator const git_checkout_options*() const
+        {
+            return &mOptions;
+        }
+
+        CheckoutOptions::operator git_checkout_options&()
+        {
+            return mOptions;
+        }
+
+        git_checkout_options& CheckoutOptions::operator *()
+        {
+            return mOptions;
+        }
+
+        const QStringList& CheckoutOptions::paths() const
+        {
+            return mPaths;
+        }
+
+        void CheckoutOptions::setPaths( const QStringList& paths )
+        {
+            mPaths = StrArray( paths );
+        }
+
+
+        //-- StrArray --------------------------------------------------------------------------- >8
 
         StrArray::StrArray(const QStringList& sl)
             : mInternalCopy( sl )

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -60,12 +60,17 @@ namespace Git
             git_buf_free( &buf );
         }
 
+        Buffer::operator QString() const
+        {
+            return toString();
+        }
+
         Buffer::operator git_buf*()
         {
             return &buf;
         }
 
-        Buffer::operator const char*()
+        Buffer::operator const char*() const
         {
             return buf.ptr;
         }

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -50,8 +50,7 @@ namespace Git
 
         //-- Buffer ----------------------------------------------------------------------------- >8
 
-        Buffer::Buffer(QTextCodec *codec)
-            : mCodec(codec)
+        Buffer::Buffer()
         {
             memset(&buf, 0, sizeof(buf));
         }
@@ -75,8 +74,6 @@ namespace Git
          * @brief        Converts the contents of the buffer into a QString.
          *
          * @return       the buffer in readable text format
-         *
-         * @note         Defaults to QString::fromUtf8() when no text codec is set.
          */
         QString Buffer::toString() const
         {

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -281,6 +281,13 @@ namespace Git
             delete[] mEncoded.strings;
 
             mEncoded.count = strings.count();
+            if ( strings.isEmpty() )
+            {
+                // The strings pointer must be NULL in this case.
+                mEncoded.strings = NULL;
+                return;
+            }
+
             mEncoded.strings = new char *[mEncoded.count];
 
             for( int i = 0; i < strings.count(); i++ )

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -125,6 +125,35 @@ namespace Git
         }
 
 
+        //-- CloneOptions ----------------------------------------------------------------------- >8
+
+        CloneOptions::CloneOptions()
+        {
+            git_clone_init_options( &mOptions, GIT_CLONE_OPTIONS_VERSION );
+            mOptions.checkout_opts = mCheckoutOptions;
+        }
+
+        CloneOptions::operator const git_clone_options*() const
+        {
+            return &mOptions;
+        }
+
+        CloneOptions::operator git_clone_options&()
+        {
+            return mOptions;
+        }
+
+        git_clone_options& CloneOptions::operator *()
+        {
+            return mOptions;
+        }
+
+        CheckoutOptions& CloneOptions::checkoutOptions()
+        {
+            return mCheckoutOptions;
+        }
+
+
         //-- StrArray --------------------------------------------------------------------------- >8
 
         StrArray::StrArray()

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -89,14 +89,24 @@ namespace Git
         //-- CheckoutOptions -------------------------------------------------------------------- >8
 
         CheckoutOptions::CheckoutOptions()
-            : mPaths( StrArrayRef( mOptions.paths ) )
         {
+            const git_checkout_options *assert_coo_ptr = &mOptions;
+            Q_UNUSED( assert_coo_ptr )
+
             git_checkout_init_options( &mOptions, GIT_CHECKOUT_OPTIONS_VERSION );
+            Q_ASSERT( assert_coo_ptr == &mOptions );
+            mPaths = QSharedPointer<StrArrayRef>( new StrArrayRef( mOptions.paths ) );
         }
 
         CheckoutOptions::CheckoutOptions(const QStringList& paths)
-            : mPaths( StrArrayRef( mOptions.paths, paths ) )
         {
+            const git_checkout_options *assert_coo_ptr = &mOptions;
+            Q_UNUSED( assert_coo_ptr )
+
+            git_checkout_init_options( &mOptions, GIT_CHECKOUT_OPTIONS_VERSION );
+            Q_ASSERT( assert_coo_ptr == &mOptions );
+            mPaths = QSharedPointer<StrArrayRef>( new StrArrayRef( mOptions.paths ) );
+            Q_ASSERT( *mPaths == mOptions.paths );
         }
 
         CheckoutOptions::operator git_checkout_options*()
@@ -121,12 +131,12 @@ namespace Git
 
         QStringList CheckoutOptions::paths() const
         {
-            return mPaths;
+            return *mPaths;
         }
 
         void CheckoutOptions::setPaths( const QStringList& paths )
         {
-            mPaths.setStrings( paths );
+            mPaths->setStrings( paths );
         }
 
 

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -94,6 +94,11 @@ namespace Git
             git_checkout_init_options( &mOptions, GIT_CHECKOUT_OPTIONS_VERSION );
         }
 
+        CheckoutOptions::CheckoutOptions(const QStringList& paths)
+            : mPaths( StrArrayRef( mOptions.paths, paths ) )
+        {
+        }
+
         CheckoutOptions::operator git_checkout_options*()
         {
             return &mOptions;

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -219,20 +219,45 @@ namespace Git
 
         //-- StrArrayRef ------------------------------------------------------------------------ >8
 
-        StrArrayRef::StrArrayRef(git_strarray& _a)
+        StrArrayRef::StrArrayRef(git_strarray& _a, bool init)
             : mEncoded( _a )
         {
+            if ( init ) {
+                mEncoded.strings = 0;
+                mEncoded.count = 0;
+            }
         }
 
         StrArrayRef::StrArrayRef(git_strarray& _a, const QStringList& strings)
             : mEncoded(_a)
         {
+            Q_ASSERT( !mEncoded.strings && !mEncoded.count );
             setStrings( strings );
         }
 
         StrArrayRef::~StrArrayRef()
         {
             delete[] mEncoded.strings;
+        }
+
+        bool StrArrayRef::operator ==(const git_strarray& other) const
+        {
+            return &mEncoded == &other;
+        }
+
+        bool StrArrayRef::operator !=(const git_strarray& other) const
+        {
+            return !(*this == other);
+        }
+
+        bool StrArrayRef::operator ==(const git_strarray* other) const
+        {
+            return &mEncoded == other;
+        }
+
+        bool StrArrayRef::operator !=(const git_strarray* other) const
+        {
+            return !(*this == other);
         }
 
         StrArrayRef::operator QStringList() const

--- a/libGitWrap/GitWrap.hpp
+++ b/libGitWrap/GitWrap.hpp
@@ -256,7 +256,7 @@ namespace Git
         CheckoutForce
     };
 
-    enum CheckoutOption
+    enum CheckoutFlag
     {
         CheckoutUpdateHEAD              = (1UL <<  0),
         CheckoutAllowDetachHEAD         = (1UL <<  1),
@@ -276,7 +276,7 @@ namespace Git
         CheckoutNone                    = 0
     };
 
-    typedef QFlags<CheckoutOption> CheckoutOptions;
+    typedef QFlags<CheckoutFlag> CheckoutFlags;
 
     typedef QHash<QString, StatusFlags> StatusHash;
 

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -428,7 +428,7 @@ namespace Git
         Internal::CheckoutOptions options( paths );
         (*options).checkout_strategy = GIT_CHECKOUT_FORCE;
 
-        result = git_checkout_index(d->repo()->mRepo, d->index, &options);
+        result = git_checkout_index(d->repo()->mRepo, d->index, options);
     }
 
     /**

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -425,9 +425,8 @@ namespace Git
     void Index::checkoutFiles(Result &result, const QStringList &paths)
     {
         GW_D_CHECKED_VOID(Index, result)
-        git_checkout_options options = GIT_CHECKOUT_OPTIONS_INIT;
-        options.checkout_strategy = GIT_CHECKOUT_FORCE;
-        Internal::StrArrayRef(options.paths, paths);
+        Internal::CheckoutOptions options( paths );
+        (*options).checkout_strategy = GIT_CHECKOUT_FORCE;
 
         result = git_checkout_index(d->repo()->mRepo, d->index, &options);
     }

--- a/libGitWrap/Operations/CheckoutOperation.cpp
+++ b/libGitWrap/Operations/CheckoutOperation.cpp
@@ -302,7 +302,7 @@ namespace Git
         d->mMode = mode;
     }
 
-    void CheckoutBaseOperation::setOptions(CheckoutOptions opts)
+    void CheckoutBaseOperation::setFlags(CheckoutFlags opts)
     {
         GW_D(CheckoutBaseOperation);
         Q_ASSERT(!isRunning());
@@ -342,7 +342,7 @@ namespace Git
         return d->mMode;
     }
 
-    CheckoutOptions CheckoutBaseOperation::options() const
+    CheckoutFlags CheckoutBaseOperation::flags() const
     {
         GW_CD(CheckoutBaseOperation);
         return d->mOptions;

--- a/libGitWrap/Operations/CheckoutOperation.hpp
+++ b/libGitWrap/Operations/CheckoutOperation.hpp
@@ -53,7 +53,7 @@ namespace Git
     public:
         void setRepository(const Repository& repo);
         void setMode(CheckoutMode mode);
-        void setOptions(CheckoutOptions opts);
+        void setFlags(CheckoutFlags opts);
         void setTargetDirectory(const QString& path);
         void setCheckoutPaths(const QStringList& paths);
         void setBaseline(const Tree& baseline);
@@ -63,7 +63,7 @@ namespace Git
     public:
         Repository repository() const;
         CheckoutMode mode() const;
-        CheckoutOptions options() const;
+        CheckoutFlags flags() const;
         QString targetDirectory() const;
         QStringList checkoutPaths() const;
         Tree baseline() const;

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -86,13 +86,6 @@ namespace Git
         (*(d->mCloneOpts)).bare = bare;
     }
 
-    void CloneOperation::setRemoteName(const QByteArray& remoteName)
-    {
-        GW_D(CloneOperation);
-        Q_ASSERT(!isRunning());
-        d->mRemoteName = remoteName;
-    }
-
     void CloneOperation::setRemoteName(const QString& remoteName)
     {
         GW_D(CloneOperation);

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -86,34 +86,6 @@ namespace Git
         (*(d->mCloneOpts)).bare = bare;
     }
 
-    void CloneOperation::setRemoteName(const QString& remoteName)
-    {
-        GW_D(CloneOperation);
-        Q_ASSERT(!isRunning());
-        d->mRemoteName = GW_EncodeQString(remoteName);
-    }
-
-    void CloneOperation::setFetchSpec(const QByteArray& fetchSpec)
-    {
-        GW_D(CloneOperation);
-        Q_ASSERT(!isRunning());
-        d->mFetchSpec = fetchSpec;
-    }
-
-    void CloneOperation::setPushSpec(const QByteArray& pushSpec)
-    {
-        GW_D(CloneOperation);
-        Q_ASSERT(!isRunning());
-        d->mPushSpec = pushSpec;
-    }
-
-    void CloneOperation::setPushUrl(const QByteArray& pushUrl)
-    {
-        GW_D(CloneOperation);
-        Q_ASSERT(!isRunning());
-        d->mPushUrl = pushUrl;
-    }
-
     QString CloneOperation::url() const
     {
         GW_CD(CloneOperation);
@@ -130,30 +102,6 @@ namespace Git
     {
         GW_CD(CloneOperation);
         return (*(d->mCloneOpts)).bare;
-    }
-
-    QByteArray CloneOperation::remoteName() const
-    {
-        GW_CD(CloneOperation);
-        return d->mRemoteName;
-    }
-
-    QByteArray CloneOperation::fetchSpec() const
-    {
-        GW_CD(CloneOperation);
-        return d->mFetchSpec;
-    }
-
-    QByteArray CloneOperation::pushSpec() const
-    {
-        GW_CD(CloneOperation);
-        return d->mPushSpec;
-    }
-
-    QByteArray CloneOperation::pushUrl() const
-    {
-        GW_CD(CloneOperation);
-        return d->mPushUrl;
     }
 
 }

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -53,7 +53,7 @@ namespace Git
             // TODO: setup the callbacks for notifications about the clone progress
 
             if (mResult) {
-                mResult = git_clone(&repo, Internal::String(mUrl), Internal::String(mPath), &mCloneOpts);
+                mResult = git_clone(&repo, mUrl.toUtf8().constData(), mPath.toUtf8().constData(), &mCloneOpts);
             }
 
             git_repository_free(repo);

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -29,9 +29,9 @@ namespace Git
 
         CloneOperationPrivate::CloneOperationPrivate(CloneOperation* owner)
             : BaseOperationPrivate(owner)
-            , mCloneBare(false)
         {
             (*mCloneOpts.checkoutOptions()).checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
+
             // TODO: setup checkout callbacks for notification about the checkout progress
         }
 
@@ -83,7 +83,7 @@ namespace Git
     {
         GW_D(CloneOperation);
         Q_ASSERT(!isRunning());
-        d->mCloneBare = bare;
+        (*(d->mCloneOpts)).bare = bare;
     }
 
     void CloneOperation::setRemoteName(const QByteArray& remoteName)
@@ -136,7 +136,7 @@ namespace Git
     bool CloneOperation::bare() const
     {
         GW_CD(CloneOperation);
-        return d->mCloneBare;
+        return (*(d->mCloneOpts)).bare;
     }
 
     QByteArray CloneOperation::remoteName() const

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -48,7 +48,7 @@ namespace Git
             // TODO: setup the callbacks for notifications about the clone progress
 
             if (mResult) {
-                mResult = git_clone(&repo, mUrl.toUtf8().constData(), mPath.toUtf8().constData(), mCloneOpts);
+                mResult = git_clone(&repo, GW_StringFromQt(mUrl), GW_StringFromQt(mPath), mCloneOpts);
             }
 
             git_repository_free(repo);

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -31,13 +31,8 @@ namespace Git
             : BaseOperationPrivate(owner)
             , mCloneBare(false)
         {
-            git_clone_options cloneOpts = GIT_CLONE_OPTIONS_INIT;
-            memcpy( &mCloneOpts, &cloneOpts, sizeof(cloneOpts) );
-
-            git_checkout_options checkoutOpts = GIT_CHECKOUT_OPTIONS_INIT;
-            checkoutOpts.checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
+            (*mCloneOpts.checkoutOptions()).checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
             // TODO: setup checkout callbacks for notification about the checkout progress
-            memcpy( &mCloneOpts.checkout_opts, &checkoutOpts, sizeof(checkoutOpts) );
         }
 
         CloneOperationPrivate::~CloneOperationPrivate()
@@ -53,7 +48,7 @@ namespace Git
             // TODO: setup the callbacks for notifications about the clone progress
 
             if (mResult) {
-                mResult = git_clone(&repo, mUrl.toUtf8().constData(), mPath.toUtf8().constData(), &mCloneOpts);
+                mResult = git_clone(&repo, mUrl.toUtf8().constData(), mPath.toUtf8().constData(), mCloneOpts);
             }
 
             git_repository_free(repo);

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -45,7 +45,7 @@ namespace Git
 
             git_repository* repo = NULL;
 
-            // TODO: setup the callbacks for notifications about the clone progress
+            RemoteCallbacks::initCallbacks( (*mCloneOpts).remote_callbacks, owner );
 
             if (mResult) {
                 mResult = git_clone(&repo, GW_StringFromQt(mUrl), GW_StringFromQt(mPath), mCloneOpts);

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -30,9 +30,9 @@ namespace Git
         CloneOperationPrivate::CloneOperationPrivate(CloneOperation* owner)
             : BaseOperationPrivate(owner)
         {
-            (*mCloneOpts.checkoutOptions()).checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
-
-            // TODO: setup checkout callbacks for notification about the checkout progress
+            CheckoutOptions& coo = mCloneOpts.checkoutOptions();
+            (*coo).checkout_strategy = GIT_CHECKOUT_SAFE_CREATE;
+            // TODO: setup checkout callbacks for notification about the checkout progres
         }
 
         CloneOperationPrivate::~CloneOperationPrivate()

--- a/libGitWrap/Operations/CloneOperation.hpp
+++ b/libGitWrap/Operations/CloneOperation.hpp
@@ -48,7 +48,6 @@ namespace Git
         void setPath(const QString& path);
         void setBare(bool bare);
         void setRemoteName(const QString& remoteName);
-        void setRemoteName(const QByteArray& remoteName);
         void setFetchSpec(const QByteArray& fetchSpec);
         void setPushSpec(const QByteArray& pushSpec);
         void setPushUrl(const QByteArray& pushUrl);

--- a/libGitWrap/Operations/CloneOperation.hpp
+++ b/libGitWrap/Operations/CloneOperation.hpp
@@ -47,20 +47,11 @@ namespace Git
         void setUrl(const QString& url);
         void setPath(const QString& path);
         void setBare(bool bare);
-        void setRemoteName(const QString& remoteName);
-        void setFetchSpec(const QByteArray& fetchSpec);
-        void setPushSpec(const QByteArray& pushSpec);
-        void setPushUrl(const QByteArray& pushUrl);
 
     public:
         QString url() const;
         QString path() const;
         bool bare() const;
-
-        QByteArray remoteName() const;
-        QByteArray fetchSpec() const;
-        QByteArray pushSpec() const;
-        QByteArray pushUrl() const;
 
     signals:
         void askCredentials( CredentialRequest& request );

--- a/libGitWrap/Operations/Private/CheckoutOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CheckoutOperationPrivate.hpp
@@ -52,7 +52,7 @@ namespace Git
 
         public:
             Repository              mRepository;
-            CheckoutOptions         mOptions;
+            CheckoutFlags           mOptions;
             CheckoutMode            mMode;
             QStringList             mPaths;
             QString                 mPath;

--- a/libGitWrap/Operations/Private/CheckoutOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CheckoutOperationPrivate.hpp
@@ -54,10 +54,9 @@ namespace Git
             Repository              mRepository;
             CheckoutFlags           mOptions;
             CheckoutMode            mMode;
-            QStringList             mPaths;
             QString                 mPath;
             Tree                    mBaseline;
-            git_checkout_options    mOpts;
+            CheckoutOptions         mOpts;
             bool                    mCancel;
         };
 

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -46,11 +46,6 @@ namespace Git
             QString                 mUrl;
             QString                 mPath;
 
-            QByteArray              mRemoteName;
-            QByteArray              mFetchSpec;
-            QByteArray              mPushSpec;
-            QByteArray              mPushUrl;
-
             CloneOptions            mCloneOpts;
         };
 

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -51,8 +51,6 @@ namespace Git
             QByteArray              mPushSpec;
             QByteArray              mPushUrl;
 
-            bool                    mCloneBare;
-
             git_remote_callbacks    mRemoteCallbacks;
             CloneOptions            mCloneOpts;
         };

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -51,7 +51,6 @@ namespace Git
             QByteArray              mPushSpec;
             QByteArray              mPushUrl;
 
-            git_remote_callbacks    mRemoteCallbacks;
             CloneOptions            mCloneOpts;
         };
 

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -54,7 +54,7 @@ namespace Git
             bool                    mCloneBare;
 
             git_remote_callbacks    mRemoteCallbacks;
-            git_checkout_options    mCheckoutOpts;
+            git_clone_options       mCloneOpts;
         };
 
     }

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -54,7 +54,7 @@ namespace Git
             bool                    mCloneBare;
 
             git_remote_callbacks    mRemoteCallbacks;
-            git_clone_options       mCloneOpts;
+            CloneOptions            mCloneOpts;
         };
 
     }

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -57,12 +57,8 @@ namespace Git
          * @brief       The Buffer class wraps a git_buf.
          */
         class Buffer {
-        private:
-            git_buf         buf;
-            QTextCodec*     mCodec;
-
         public:
-            Buffer( QTextCodec* codec = 0 );
+            Buffer();
             ~Buffer();
 
         public:
@@ -75,6 +71,9 @@ namespace Git
         private:
             Buffer(const Buffer& other);
             Buffer& operator =(const Buffer& other);
+
+        private:
+            git_buf         buf;
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -170,6 +170,30 @@ namespace Git
         /**
          * @internal
          * @ingroup     GitWrap
+         * @brief       Wraps git_clone_options.
+         */
+        class CloneOptions
+        {
+        public:
+            CloneOptions();
+
+        public:
+            operator const git_clone_options*() const;
+            operator git_clone_options&();
+
+            git_clone_options& operator *();
+
+        public:
+            CheckoutOptions& checkoutOptions();
+
+        private:
+            CheckoutOptions     mCheckoutOptions;
+            git_clone_options   mOptions;
+        };
+
+        /**
+         * @internal
+         * @ingroup     GitWrap
          * @brief       convert GitWrap's TreeEntryAttributes convert to LibGit2 file mode
          * @param[in]   attr    GitWrap's TreeEntryAttributes
          * @return      LibGit2's git_filemode_t

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -146,6 +146,7 @@ namespace Git
         {
         public:
             CheckoutOptions();
+            CheckoutOptions( const QStringList& paths );
 
         public:
             operator git_checkout_options*();

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -80,42 +80,58 @@ namespace Git
         /**
          * @internal
          * @ingroup     GitWrap
-         * @brief       Wraps a QStringList as a pointer to git_strarray.
+         * @brief       Wraps a git_strarray for conversion from and to a QStringList.
          */
         class StrArray
         {
         public:
-            StrArray(const QStringList& sl = QStringList());
+            StrArray();
+            StrArray(const QStringList& strings);
             ~StrArray();
 
         public:
-            StrArray( const StrArray& other );
-
-        public:
-            StrArray& operator=(const StrArray& other);
             operator git_strarray*();
             operator const git_strarray*() const;
 
-            operator const QStringList&() const;
+            operator QStringList() const;
+
+        public:
+            QStringList strings() const;
+            void setStrings( const QStringList& strings);
+
+        private:
+            StrArray( const StrArray& other );
+            StrArray& operator=(const StrArray& other);
 
         private:
             git_strarray          mEncoded;         //!< the encoded string data from the source QStringList
-            QStringList           mInternalCopy;    //!< a light copy of the source QStringList
         };
 
+        /**
+         * @internal
+         * @ingroup     GitWrap
+         * @brief       Wraps an existing git_strarray for conversion from and to a QStringList.
+         */
         class StrArrayRef
         {
         public:
+            StrArrayRef(git_strarray& _a);
             StrArrayRef(git_strarray& _a, const QStringList& sl);
             ~StrArrayRef();
+
+        public:
+            operator QStringList() const;
 
         private:
             /* Cannot privatize Copy+Default ctor because of the member-by-reference */
             StrArrayRef& operator=(const StrArrayRef&);
 
+        public:
+            QStringList strings() const;
+            void setStrings( const QStringList& strings );
+
         private:
             git_strarray&       mEncoded;
-            QStringList         mInternalCopy;
         };
 
 
@@ -147,7 +163,7 @@ namespace Git
 
         private:
             git_checkout_options        mOptions;
-            StrArray                    mPaths;
+            StrArrayRef                 mPaths;
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -168,8 +168,8 @@ namespace Git
             CheckoutOptions& operator =(const CheckoutOptions& other);
 
         private:
-            git_checkout_options        mOptions;
-            StrArrayRef                 mPaths;
+            git_checkout_options            mOptions;
+            QSharedPointer<StrArrayRef>     mPaths;
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -39,9 +39,9 @@ namespace Git
     namespace Internal
     {
 
-        class RepositoryPrivate;
         class IndexPrivate;
         class ObjectPrivate;
+        class RepositoryPrivate;
 
         // Some internal helpers
         Signature git2Signature( const git_signature* gitsig );
@@ -75,6 +75,7 @@ namespace Git
         private:
             git_buf         buf;
         };
+
 
         /**
          * @internal
@@ -115,6 +116,38 @@ namespace Git
         private:
             git_strarray&       mEncoded;
             QStringList         mInternalCopy;
+        };
+
+
+        // -- git_..._options wrappers
+
+        /**
+         * @internal
+         * @brief Wraps git_checkout_options.
+         */
+        class CheckoutOptions
+        {
+        public:
+            CheckoutOptions();
+
+        public:
+            operator git_checkout_options*();
+            operator const git_checkout_options*() const;
+            operator git_checkout_options&();
+
+            git_checkout_options& operator *();
+
+        public:
+            const QStringList& paths() const;
+            void setPaths( const QStringList& paths );
+
+        private:
+            CheckoutOptions(const CheckoutOptions& other);
+            CheckoutOptions& operator =(const CheckoutOptions& other);
+
+        private:
+            git_checkout_options        mOptions;
+            StrArray                    mPaths;
         };
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -139,7 +139,8 @@ namespace Git
 
         /**
          * @internal
-         * @brief Wraps git_checkout_options.
+         * @ingroup     GitWrap
+         * @brief       Wraps git_checkout_options.
          */
         class CheckoutOptions
         {
@@ -154,7 +155,7 @@ namespace Git
             git_checkout_options& operator *();
 
         public:
-            const QStringList& paths() const;
+            QStringList paths() const;
             void setPaths( const QStringList& paths );
 
         private:

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -127,7 +127,7 @@ namespace Git
         {
             switch( attr )
             {
-            case UnkownAttr:            return GIT_FILEMODE_NEW;
+            case UnkownAttr:            return GIT_FILEMODE_UNREADABLE;
             case TreeAttr:              return GIT_FILEMODE_TREE;
             case FileAttr:              return GIT_FILEMODE_BLOB;
             case FileExecutableAttr:    return GIT_FILEMODE_BLOB_EXECUTABLE;
@@ -136,7 +136,7 @@ namespace Git
             }
             Q_ASSERT( false );
             // Why is there no "Q_ASSUME( false );"???
-            return GIT_FILEMODE_NEW;
+            return GIT_FILEMODE_UNREADABLE;
         }
 
         /**

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -18,7 +18,6 @@
 #define GIT_P_H
 
 #include <QDebug>
-#include <QTextCodec>
 #include <QThreadStorage>
 
 #include "git2.h"

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -63,7 +63,8 @@ namespace Git
 
         public:
             operator git_buf*();
-            operator const char*();
+            operator const char*() const;
+            operator QString() const;
 
         public:
             QString toString() const;

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -115,11 +115,15 @@ namespace Git
         class StrArrayRef
         {
         public:
-            StrArrayRef(git_strarray& _a);
+            StrArrayRef(git_strarray& _a, bool init = false);
             StrArrayRef(git_strarray& _a, const QStringList& sl);
             ~StrArrayRef();
 
         public:
+            bool operator ==(const git_strarray& other) const;
+            bool operator !=(const git_strarray& other) const;
+            bool operator ==(const git_strarray* other) const;
+            bool operator !=(const git_strarray* other) const;
             operator QStringList() const;
 
         private:

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -84,20 +84,22 @@ namespace Git
         class StrArray
         {
         public:
-            StrArray(const QStringList& sl);
+            StrArray(const QStringList& sl = QStringList());
             ~StrArray();
 
+        public:
+            StrArray( const StrArray& other );
+
+        public:
+            StrArray& operator=(const StrArray& other);
             operator git_strarray*();
             operator const git_strarray*() const;
 
-        private:
-            StrArray();
-            StrArray(const StrArray&);
-            StrArray& operator=(const StrArray&);
+            operator const QStringList&() const;
 
         private:
-            git_strarray a;
-            QVector<QByteArray>   mEncoded;
+            git_strarray          mEncoded;         //!< the encoded string data from the source QStringList
+            QStringList           mInternalCopy;    //!< a light copy of the source QStringList
         };
 
         class StrArrayRef
@@ -111,8 +113,8 @@ namespace Git
             StrArrayRef& operator=(const StrArrayRef&);
 
         private:
-            git_strarray& a;
-            QVector<QByteArray> mEncoded;
+            git_strarray&       mEncoded;
+            QStringList         mInternalCopy;
         };
 
         /**

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -501,7 +501,7 @@ namespace Git
         GW_D_CHECKED_VOID(Reference, result);
 
         git_reference* newRef = NULL;
-        result = git_reference_rename(&newRef, d->reference, newName.toUtf8().constData(), force, NULL, NULL);
+        result = git_reference_rename(&newRef, d->reference, GW_StringFromQt(newName), force, NULL, NULL);
 
         if (result && (newRef != d->reference)) {
             git_reference_free(d->reference);

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -406,7 +406,7 @@ namespace Git
     }
 
     void Reference::checkout(Result&            result,
-                             CheckoutOptions    opts,
+                             CheckoutFlags      flags,
                              CheckoutMode       mode,
                              const QStringList& paths) const
     {
@@ -418,7 +418,7 @@ namespace Git
             return;
         }
 
-        bool doUpdateHEAD    = opts.testFlag(CheckoutUpdateHEAD);
+        bool doUpdateHEAD    = flags.testFlag(CheckoutUpdateHEAD);
         /*
         bool doCreateLocal   = opts.testFlag(CheckoutCreateLocalBranch);
         bool doAllowDetached = opts.testFlag(CheckoutAllowDetachHEAD);
@@ -434,7 +434,7 @@ namespace Git
         }
         */
 
-        op->setOptions(opts);
+        op->setFlags(flags);
         op->setMode(mode);
         op->setCheckoutPaths(paths);
         op->setBackgroundMode(false);

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -92,7 +92,7 @@ namespace Git
 
         CheckoutBaseOperation* checkoutOperation(Result& result) const;
         void checkout( Result& result,
-                       CheckoutOptions opts = CheckoutNone,
+                       CheckoutFlags flags = CheckoutNone,
                        CheckoutMode mode = CheckoutSafeCreate,
                        const QStringList &paths = QStringList() ) const;
 

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -59,8 +59,8 @@ namespace Git
         Repository::Private* rp = Private::dataOf<Repository>(repository);
 
         git_remote* remote = NULL;
-        result = git_remote_create(&remote, rp->mRepo, name.toUtf8().constData(),
-                                   url.toUtf8().constData() );
+        result = git_remote_create(&remote, rp->mRepo, GW_StringFromQt(name),
+                                   GW_StringFromQt(url) );
         if (!result) {
             return Remote();
         }
@@ -111,7 +111,7 @@ namespace Git
     {
         GW_D_CHECKED(Remote, false, result);
 
-        result = git_remote_add_fetch( d->mRemote, spec.toUtf8().constData() );
+        result = git_remote_add_fetch( d->mRemote, GW_StringFromQt(spec) );
         return result;
     }
 
@@ -119,7 +119,7 @@ namespace Git
     {
         GW_D_CHECKED(Remote, false, result);
 
-        result = git_remote_add_push( d->mRemote, spec.toUtf8().constData() );
+        result = git_remote_add_push( d->mRemote, GW_StringFromQt(spec) );
         return result;
     }
 
@@ -168,7 +168,7 @@ namespace Git
 
     bool Remote::isSupportedUrl( const QString& url )
     {
-        return git_remote_supported_url( url.toUtf8().constData() );
+        return git_remote_supported_url( GW_StringFromQt(url) );
     }
 
     bool Remote::connect(Result& result, bool forFetch)

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -190,7 +190,7 @@ namespace Git
     bool Remote::download( Result& result, const QStringList &refspecs )
     {
         GW_D_CHECKED(Remote, false, result);
-        result = git_remote_download(d->mRemote, Internal::StrArrayWrapper(refspecs));
+        result = git_remote_download(d->mRemote, Internal::StrArray(refspecs));
         return result;
     }
 

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -168,7 +168,7 @@ namespace Git
 
     bool Remote::isSupportedUrl( const QString& url )
     {
-        return git_remote_supported_url( GW_StringFromQt(url) );
+        return true;
     }
 
     bool Remote::connect(Result& result, bool forFetch)

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -187,10 +187,10 @@ namespace Git
         git_remote_disconnect(d->mRemote);
     }
 
-    bool Remote::download( Result& result )
+    bool Remote::download( Result& result, const QStringList &refspecs )
     {
         GW_D_CHECKED(Remote, false, result);
-        result = git_remote_download(d->mRemote);
+        result = git_remote_download(d->mRemote, Internal::StrArrayWrapper(refspecs));
         return result;
     }
 

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -67,7 +67,7 @@ namespace Git
 
         bool connect(Result& result, bool forFetch);
         void disconnect(Result& result);
-        bool download(Result& result);
+        bool download(Result& result, const QStringList &refspecs = QStringList());
         bool updateTips(Result& result);
     };
 

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -39,7 +39,7 @@ namespace Git
      */
     class GITWRAP_API Remote : public RepoObject
     {
-        GW_PRIVATE_DECL(Remote, RepoObject, public);
+        GW_PRIVATE_DECL(Remote, RepoObject, public)
 
     public:
         typedef RemoteList List;

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -63,7 +63,7 @@ namespace Git
         QVector<RefSpec> pushSpecs() const;
 
         GW_DEPRECATED static bool isValidUrl(const QString& url);
-        static bool isSupportedUrl(const QString& url);
+        GW_DEPRECATED static bool isSupportedUrl(const QString& url);
 
         bool connect(Result& result, bool forFetch);
         void disconnect(Result& result);

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -237,8 +237,7 @@ namespace Git
         }
         git_repository* repo = NULL;
 
-
-        result = git_repository_open( &repo, path.toUtf8().constData() );
+        result = git_repository_open( &repo, GW_StringFromQt( path ) );
         if( !result )
         {
             return Repository();

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -149,7 +149,7 @@ namespace Git
         }
 
         git_repository* repo = NULL;
-        result = git_repository_init( &repo, path.toUtf8().constData(), bare );
+        result = git_repository_init( &repo, GW_StringFromQt(path), bare );
 
         if( !result )
         {
@@ -196,9 +196,9 @@ namespace Git
         }
 
         git_buf repoPath = {0};
-        QByteArray joinedCeilingDirs = ceilingDirs.join(QChar::fromLatin1(GIT_PATH_LIST_SEPARATOR)).toUtf8();
+        QByteArray joinedCeilingDirs = GW_EncodeQString( ceilingDirs.join(QChar::fromLatin1(GIT_PATH_LIST_SEPARATOR)) );
 
-        result = git_repository_discover( &repoPath, startPath.toUtf8().constData(),
+        result = git_repository_discover( &repoPath, GW_StringFromQt(startPath),
                                           acrossFs, joinedCeilingDirs.constData() );
 
         QString resultPath;
@@ -348,7 +348,7 @@ namespace Git
         unsigned int status = GIT_STATUS_CURRENT;
         GW_CD_CHECKED(Repository, FileInvalidStatus, result);
 
-        result = git_status_file( &status, d->mRepo, fileName.toUtf8().data() );
+        result = git_status_file( &status, d->mRepo, GW_StringFromQt(fileName) );
         if (!result) {
             return FileInvalidStatus;
         }
@@ -530,12 +530,12 @@ namespace Git
 
         git_reference* ref = NULL;
 
-        result = git_branch_lookup( &ref, d->mRepo, oldName.toUtf8().constData(),
+        result = git_branch_lookup( &ref, d->mRepo, GW_StringFromQt(oldName),
                                     GIT_BRANCH_LOCAL );
 
         if( result.errorCode() == GITERR_REFERENCE )
         {
-            result = git_branch_lookup( &ref, d->mRepo, oldName.toUtf8().constData(),
+            result = git_branch_lookup( &ref, d->mRepo, GW_StringFromQt(oldName),
                                         GIT_BRANCH_REMOTE );
         }
 
@@ -545,7 +545,7 @@ namespace Git
         }
 
         git_reference* refOut = NULL;
-        result = git_branch_move( &refOut, ref, newName.toUtf8().constData(), force, NULL, NULL );
+        result = git_branch_move( &refOut, ref, GW_StringFromQt(newName), force, NULL, NULL );
 
         if( result )
         {
@@ -722,7 +722,7 @@ namespace Git
 
         int ignore = 0;
 
-        result = git_status_should_ignore( &ignore, d->mRepo, filePath.toUtf8().constData() );
+        result = git_status_should_ignore( &ignore, d->mRepo, GW_StringFromQt(filePath) );
         if( !result )
         {
             return false;
@@ -804,7 +804,7 @@ namespace Git
         GW_CD_EX_CHECKED(Repository, Remote(), result);
 
         git_remote* remote = NULL;
-        result = git_remote_load( &remote, d->mRepo, remoteName.toUtf8().constData() );
+        result = git_remote_load( &remote, d->mRepo, GW_StringFromQt(remoteName) );
 
         if( !result )
         {
@@ -967,7 +967,7 @@ namespace Git
     {
         GW_D_CHECKED_VOID(Repository, result);
 
-        result = git_repository_set_head( d->mRepo, branchName.toUtf8().constData(), NULL, NULL );
+        result = git_repository_set_head( d->mRepo, GW_StringFromQt(branchName), NULL, NULL );
     }
 
     /**
@@ -1069,7 +1069,7 @@ namespace Git
 
         git_reference* ref = NULL;
         if (dwim) {
-            result = git_reference_dwim(&ref, d->mRepo, refName.toUtf8().constData());
+            result = git_reference_dwim(&ref, d->mRepo, GW_StringFromQt(refName));
 
             if (!result) {
                 return Reference();
@@ -1078,7 +1078,7 @@ namespace Git
             name = GW_StringToQt(git_reference_name(ref));
         }
         else {
-            result = git_reference_lookup( &ref, d->mRepo, refName.toUtf8().constData() );
+            result = git_reference_lookup( &ref, d->mRepo, GW_StringFromQt(refName) );
 
             if (!result) {
                 return Reference();

--- a/libGitWrap/Result.hpp
+++ b/libGitWrap/Result.hpp
@@ -19,6 +19,7 @@
 
 #include "libGitWrap/GitWrap.hpp"
 
+
 namespace Git
 {
 
@@ -153,3 +154,16 @@ namespace Git
 
 #endif
 
+
+//-- macro definitions -->8
+
+/**
+  * @ingroup    GitWrap
+  * @def        Check, if a given @ref Git::Result object is valid.
+  *             The current function will exit with the defined return value,
+  *             when the result is invalid.
+  */
+#define GW_CHECK_RESULT(result, returns) \
+    if (!(result)) { \
+    qDebug("Git returned error code (%d) \"%s\"", (result).errorCode(), qPrintable((result).errorText())); \
+    return (returns); }

--- a/libGitWrap/RevisionWalker.cpp
+++ b/libGitWrap/RevisionWalker.cpp
@@ -84,7 +84,7 @@ namespace Git
     void RevisionWalker::pushRef(Result& result, const QString& name)
     {
         GW_D_CHECKED_VOID(RevisionWalker, result);
-        result = git_revwalk_push_ref( d->mWalker, name.toUtf8().constData() );
+        result = git_revwalk_push_ref( d->mWalker, GW_StringFromQt(name) );
     }
 
     void RevisionWalker::pushHead( Result& result )
@@ -107,7 +107,7 @@ namespace Git
     void RevisionWalker::hideRef(Result& result, const QString& name)
     {
         GW_D_CHECKED_VOID(RevisionWalker, result);
-        result = git_revwalk_hide_ref( d->mWalker, name.toUtf8().constData() );
+        result = git_revwalk_hide_ref( d->mWalker, GW_StringFromQt(name) );
     }
 
     void RevisionWalker::hideHead( Result& result )

--- a/libGitWrap/Signature.cpp
+++ b/libGitWrap/Signature.cpp
@@ -46,8 +46,8 @@ namespace Git
             git_signature* gitsig = 0;
 
             result = git_signature_new( &gitsig,
-                                        sig.name().toUtf8().constData(),
-                                        sig.email().toUtf8().constData(),
+                                        GW_StringFromQt(sig.name()),
+                                        GW_StringFromQt(sig.email()),
                                         sig.when().toTime_t(),
                                         sig.when().utcOffset() / 60 );
 

--- a/libGitWrap/Submodule.cpp
+++ b/libGitWrap/Submodule.cpp
@@ -73,7 +73,7 @@ namespace Git
             git_submodule* sm = NULL;
 
             if (rc && repo() && !mName.isEmpty()) {
-                rc = git_submodule_lookup(&sm, repo()->mRepo, mName.toUtf8().constData());
+                rc = git_submodule_lookup(&sm, repo()->mRepo, GW_StringFromQt(mName));
                 if (!rc) {
                     return NULL;
                 }

--- a/libGitWrap/Tree.cpp
+++ b/libGitWrap/Tree.cpp
@@ -62,7 +62,7 @@ namespace Git
     {
         GW_CD_CHECKED(Tree, Tree(), result)
 
-        const git_tree_entry* entry = git_tree_entry_byname(d->o(), pathName.toUtf8().constData());
+        const git_tree_entry* entry = git_tree_entry_byname(d->o(), GW_StringFromQt(pathName));
         if (!entry) {
             return Tree();
         }
@@ -147,7 +147,7 @@ namespace Git
             return TreeEntry();
         }
 
-        const git_tree_entry* entry = git_tree_entry_byname(d->o(), fileName.toUtf8().constData());
+        const git_tree_entry* entry = git_tree_entry_byname(d->o(), GW_StringFromQt(fileName));
         return TreeEntry::PrivatePtr(new TreeEntry::Private(entry));
     }
 

--- a/libGitWrap/Tree.cpp
+++ b/libGitWrap/Tree.cpp
@@ -155,11 +155,10 @@ namespace Git
     {
         GW_CD_CHECKED_VOID(Tree, result);
 
-        git_checkout_options opts = GIT_CHECKOUT_OPTIONS_INIT;
-        opts.checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
-        Internal::StrArrayRef(opts.paths, paths);
+        Internal::CheckoutOptions opts( paths );
+        (*opts).checkout_strategy = force ? GIT_CHECKOUT_FORCE : GIT_CHECKOUT_SAFE;
 
-        result = git_checkout_tree(d->repo()->mRepo, d->mObj, &opts);
+        result = git_checkout_tree(d->repo()->mRepo, d->mObj, opts);
     }
 
     TreeEntry Tree::operator[](const QString& fileName) const

--- a/libGitWrap/TreeBuilder.cpp
+++ b/libGitWrap/TreeBuilder.cpp
@@ -61,7 +61,7 @@ namespace Git
     {
         GW_D_CHECKED(TreeBuilder, false, result);
 
-        result = git_treebuilder_remove( d->mBuilder, fileName.toUtf8().constData() );
+        result = git_treebuilder_remove( d->mBuilder, GW_StringFromQt(fileName) );
         return result;
     }
 
@@ -73,7 +73,7 @@ namespace Git
         const git_tree_entry* te = NULL;
         git_filemode_t fm = Internal::teattr2filemode( type );
 
-        result = git_treebuilder_insert( &te, d->mBuilder, fileName.toUtf8().constData(),
+        result = git_treebuilder_insert( &te, d->mBuilder, GW_StringFromQt(fileName),
                                          (const git_oid*) oid.raw(), fm );
 
         /* ignoring the returned tree-entry pointer; can be fetched by 'get' */
@@ -100,7 +100,7 @@ namespace Git
     {
         GW_D_CHECKED(TreeBuilder, TreeEntry(), result);
 
-        const git_tree_entry* entry = git_treebuilder_get( d->mBuilder, name.toUtf8().constData() );
+        const git_tree_entry* entry = git_treebuilder_get( d->mBuilder, GW_StringFromQt(name) );
         if( !entry )
         {
             return TreeEntry();

--- a/testGitWrap/Infra/Fixture.cpp
+++ b/testGitWrap/Infra/Fixture.cpp
@@ -97,7 +97,8 @@ QString Fixture::prepareRepo(const char* name)
 
     QDir(TempDirProvider::get()).mkpath(QLatin1String(name));
 
-    copyDir(sourceDir, destDir);
+    if ( !copyDir(sourceDir, destDir) )
+        qCritical( "copyDir() failed: src=%s -> dest=%s", qPrintable(sourceDir), qPrintable(destDir) );
 
     return destDir;
 }

--- a/testGitWrap/Infra/Fixture.hpp
+++ b/testGitWrap/Infra/Fixture.hpp
@@ -25,6 +25,8 @@
 
 #include "gtest/gtest.h"
 
+#define CHECK_GIT_RESULT(r) ASSERT_TRUE((r)) << "Git::Result failed: " << qPrintable((r).errorText())
+
 class Fixture : public QObject, public ::testing::Test
 {
     Q_OBJECT

--- a/testGitWrap/Infra/TempRepo.cpp
+++ b/testGitWrap/Infra/TempRepo.cpp
@@ -35,10 +35,9 @@ TempRepo::~TempRepo()
     QDir(mTempRepoDir).rmpath(QLatin1String("."));
 }
 
-TempRepoOpener::TempRepoOpener(Fixture* fixture, const char* name)
+TempRepoOpener::TempRepoOpener(Fixture* fixture, const char* name, Git::Result& r)
     : mTempRepo(fixture, name)
 {
-    Git::Result r;
     mRepo = Git::Repository::open(mTempRepo, r);
 }
 

--- a/testGitWrap/Infra/TempRepo.hpp
+++ b/testGitWrap/Infra/TempRepo.hpp
@@ -52,7 +52,7 @@ private:
 class TempRepoOpener
 {
 public:
-    TempRepoOpener(Fixture* fixture, const char* name);
+    TempRepoOpener(Fixture* fixture, const char* name, Git::Result &r);
     ~TempRepoOpener();
 
 public:

--- a/testGitWrap/TestReference.cpp
+++ b/testGitWrap/TestReference.cpp
@@ -31,13 +31,14 @@ typedef Fixture ReferenceFixture;
 
 TEST_F(ReferenceFixture, CanLookup)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
+    Git::Result r;
+    TempRepoOpener tempRepo(this, "SimpleRepo1", r);
+    CHECK_GIT_RESULT(r);
     Git::Repository repo(tempRepo);
     ASSERT_TRUE(repo.isValid());
 
-    Git::Result r;
     Git::Reference ref = repo.reference(r, QLatin1String("refs/heads/master"));
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_TRUE(ref.isValid());
     ASSERT_FALSE(ref.wasDestroyed());
 
@@ -57,13 +58,14 @@ TEST_F(ReferenceFixture, CanLookup)
 
 TEST_F(ReferenceFixture, CanLookupShorthand)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
+    Git::Result r;
+    TempRepoOpener tempRepo(this, "SimpleRepo1", r);
+    CHECK_GIT_RESULT(r);
     Git::Repository repo(tempRepo);
     ASSERT_TRUE(repo.isValid());
 
-    Git::Result r;
     Git::Reference ref = repo.reference(r, QLatin1String("master"), true);
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_TRUE(ref.isValid());
     ASSERT_FALSE(ref.wasDestroyed());
 
@@ -78,25 +80,26 @@ TEST_F(ReferenceFixture, CanLookupShorthand)
 
 TEST_F(ReferenceFixture, CanDestroyRef)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
+    Git::Result r;
+    TempRepoOpener tempRepo(this, "SimpleRepo1", r);
+    CHECK_GIT_RESULT(r);
     Git::Repository repo(tempRepo);
     ASSERT_TRUE(repo.isValid());
 
-    Git::Result r;
     Git::Reference ref = repo.reference(r, QLatin1String("master"), true);
     ASSERT_FALSE(ref.wasDestroyed());
 
     ref.destroy(r);
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_TRUE(ref.wasDestroyed());
 
     ASSERT_TRUE(ref.objectId().isNull());
 
     // counter check
     Git::Repository repo2 = repo.reopen(r);
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
 
     QStringList sl = repo2.allBranchNames(r);
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_EQ(0, sl.count());
 }

--- a/testGitWrap/TestRepository.cpp
+++ b/testGitWrap/TestRepository.cpp
@@ -29,7 +29,9 @@ typedef Fixture RepositoryFixture;
 
 TEST_F(RepositoryFixture, CanOpen)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
+    Git::Result r;
+    TempRepoOpener tempRepo(this, "SimpleRepo1", r);
+    CHECK_GIT_RESULT(r);
     Git::Repository repo(tempRepo);
     ASSERT_TRUE(repo.isValid());
 
@@ -41,33 +43,35 @@ TEST_F(RepositoryFixture, CanOpen)
 
 TEST_F(RepositoryFixture, CanListBranches)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
+    Git::Result r;
+    TempRepoOpener tempRepo(this, "SimpleRepo1", r);
+    CHECK_GIT_RESULT(r);
     Git::Repository repo(tempRepo);
     ASSERT_TRUE(repo.isValid());
 
-    Git::Result r;
     QStringList sl = repo.branchNames(r, true, false);
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_EQ(1, sl.count());
     EXPECT_STREQ("master",
                  qPrintable(sl[0]));
 
     sl = repo.branchNames(r, false, true);
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_EQ(0, sl.count());
 }
 
 TEST_F(RepositoryFixture, CanDetachHEAD)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
+    Git::Result r;
+    TempRepoOpener tempRepo(this, "SimpleRepo1", r);
+    CHECK_GIT_RESULT(r);
     Git::Repository repo(tempRepo);
     ASSERT_TRUE(repo.isValid());
 
     ASSERT_FALSE(repo.isHeadDetached());
 
-    Git::Result r;
     ASSERT_TRUE(repo.detachHead(r));
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
 
     ASSERT_TRUE(repo.isHeadDetached());
 }

--- a/testGitWrap/Test_Commit.cpp
+++ b/testGitWrap/Test_Commit.cpp
@@ -32,20 +32,20 @@ typedef Fixture CommitFixture;
 
 TEST_F(CommitFixture, CanCreateFirstCommitFromTree)
 {
-    TempRepoOpener tempRepo(this, "SimpleRepo1");
-    Git::Repository repo(tempRepo);
+    Git::Result r;
+    Git::Repository repo( TempRepoOpener(this, "SimpleRepo1", r) );
+    CHECK_GIT_RESULT(r);
     ASSERT_TRUE(repo.isValid());
 
-    Git::Result r;
-
-    Git::Signature sig;
+    Git::Signature sig = Git::Signature::defaultSignature(r, repo);
+    CHECK_GIT_RESULT(r);
     Git::Tree tree;
     Git::Commit commit = Git::Commit::create( r, repo, tree, QString::fromUtf8("Initial Commit"), sig, sig, Git::ObjectIdList() );
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_TRUE(commit.isValid());
 
     Git::Commit lookedUp = repo.lookupCommit( r, commit.id() );
-    ASSERT_TRUE(r);
+    CHECK_GIT_RESULT(r);
     ASSERT_TRUE(lookedUp.isValid());
     ASSERT_EQ( commit, lookedUp );
     ASSERT_EQ( commit.id(), lookedUp.id() );


### PR DESCRIPTION
I set this PR up mainly because of an major change in the inner workings of `Git::CloneOperation`. It now uses the available `git_clone_options`.

:checkered_flag: TODO's:
- [x] After merging the `Git::String` wrapper (whatever its final name will be). The changes must be taken here as well.
- [x] Implement wrappers for `git_checkout_options` and `git_clone_options`
