### PR TITLE
forward operation result in finished signal

### DIFF
--- a/libGitWrap/Operations/BaseOperation.cpp
+++ b/libGitWrap/Operations/BaseOperation.cpp
@@ -84,7 +84,7 @@ namespace Git
     {
         delete mData->mThread;
         mData->mThread = NULL;
-        emit finished();
+        emit finished( mData->mResult );
     }
 
     Result BaseOperation::result() const

--- a/libGitWrap/Operations/BaseOperation.hpp
+++ b/libGitWrap/Operations/BaseOperation.hpp
@@ -53,7 +53,7 @@ namespace Git
         Result result() const;
 
     signals:
-        void finished();
+        void finished(const Git::Result& result);
 
     private slots:
         void workerFinished();


### PR DESCRIPTION
Thinking about, that this doesn't really hurt ... This allows us to review the result of an operation and give the user a helpful hint on what went wrong and what to do. The error messages are very close to the Git commandline.

The alternate is to keep a member of an (asynchronus) operation and request the result within the `finished()` slot. But we can do that still either. This is just an easy way :sun_with_face: 
