### PR TITLE
Extended Operations-API

### DIFF
--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -105,7 +105,7 @@ namespace Git
                 this->init( );
             }
 
-            mPaths = QSharedPointer<StrArrayRef>( new StrArrayRef( mOptionsRef.paths ) );
+            mPaths = new StrArrayRef( mOptionsRef.paths );
         }
 
         CheckoutOptionsRef::CheckoutOptionsRef(git_checkout_options& ref, const QStringList& paths, bool init)
@@ -116,9 +116,9 @@ namespace Git
                 this->init();
             }
 
-            mPaths = QSharedPointer<StrArrayRef>( new StrArrayRef( mOptionsRef.paths ) );
+            mPaths = new StrArrayRef( mOptionsRef.paths );
             mPaths->setStrings( paths );
-            Q_ASSERT( mPaths == mOptionsRef.paths );
+            Q_ASSERT( (*mPaths) == mOptionsRef.paths );
         }
 
         void CheckoutOptionsRef::init()

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -358,7 +358,7 @@ namespace Git
 
     GitWrap::GitWrap()
     {
-        git_threads_init();
+        git_libgit2_init();
 
         Q_ASSERT( Internal::GitWrapPrivate::self == NULL );
         Internal::GitWrapPrivate::self = new Internal::GitWrapPrivate;
@@ -370,7 +370,7 @@ namespace Git
         delete Internal::GitWrapPrivate::self;
         Internal::GitWrapPrivate::self = NULL;
 
-        git_threads_shutdown();
+        git_libgit2_shutdown();
     }
 
     Result& GitWrap::lastResult()

--- a/libGitWrap/GitWrap.cpp
+++ b/libGitWrap/GitWrap.cpp
@@ -220,6 +220,11 @@ namespace Git
             delete[] mEncoded.strings;
         }
 
+        int StrArray::count() const
+        {
+            return mEncoded.count;
+        }
+
         StrArray::operator git_strarray*()
         {
             return &mEncoded;
@@ -301,6 +306,11 @@ namespace Git
         bool StrArrayRef::operator !=(const git_strarray* other) const
         {
             return !(*this == other);
+        }
+
+        int StrArrayRef::count() const
+        {
+            return mEncoded.count;
         }
 
         StrArrayRef::operator QStringList() const

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -55,7 +55,12 @@ namespace Git
         {
             GW_CHECK_RESULT( mResult, void() );
 
+            if ( mRemote )
+            {
 
+                (*mCloneOpts).remote_cb = CB_GetRemote;
+                (*mCloneOpts).remote_cb_payload = mRemote->mRemote;
+            }
 
             git_repository* clone = NULL;
             mResult = git_clone(&clone, GW_StringFromQt(mUrl), GW_StringFromQt(mPath), mCloneOpts);

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -14,8 +14,6 @@
  *
  */
 
-#include <QStringBuilder>
-
 #include "libGitWrap/Operations/CloneOperation.hpp"
 #include "libGitWrap/Operations/Private/CloneOperationPrivate.hpp"
 
@@ -38,7 +36,7 @@ namespace Git
 
         void CloneOperationPrivate::run()
         {
-            GW_OP_OWNER(CloneOperation);
+            GW_CHECK_RESULT( mResult, void() );
 
             git_repository* repo = NULL;
 
@@ -81,7 +79,7 @@ namespace Git
     {
         GW_D(CloneOperation);
         Q_ASSERT( !isRunning() );
-        if ( depth > 0 ) {
+        if ( depth ) {
             // TODO: not implemented in libgit2 api
             d->mResult.setError( "Setting the clone depth is not yet supported.", GIT_EUSER );
             qWarning( "%s: Missing implementation in libgit2 API.", __FUNCTION__ );

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -57,6 +57,7 @@ namespace Git
 
             if ( mRemote )
             {
+                Q_ASSERT( !mRemote->repo() );
 
                 (*mCloneOpts).remote_cb = CB_GetRemote;
                 (*mCloneOpts).remote_cb_payload = mRemote->mRemote;

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -66,7 +66,7 @@ namespace Git
     }
 
     CloneOperation::CloneOperation(QObject* parent)
-        : BaseRemoteOperation(*new Private(this), parent)
+        : BaseRemoteOperation( *new Private(this), parent )
     {
     }
 

--- a/libGitWrap/Operations/CloneOperation.cpp
+++ b/libGitWrap/Operations/CloneOperation.cpp
@@ -14,8 +14,8 @@
  *
  */
 
-#include "libGitWrap/Operations/CloneOperation.hpp"
-#include "libGitWrap/Operations/Private/CloneOperationPrivate.hpp"
+#include "CloneOperation.hpp"
+#include "Private/CloneOperationPrivate.hpp"
 
 #include "libGitWrap/Events/Private/GitEventCallbacks.hpp"
 

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -45,8 +45,6 @@ namespace Git
             void run();
 
         public:
-            RepositoryPrivate::Ptr  mClonedRepo;
-
             QString                 mUrl;
             QString                 mPath;
 

--- a/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
+++ b/libGitWrap/Operations/Private/CloneOperationPrivate.hpp
@@ -35,6 +35,9 @@ namespace Git
          */
         class CloneOperationPrivate : public BaseRemoteOperationPrivate
         {
+        private:
+            static int CB_CreateRepository( git_repository** out, const char* path, int bare, void* payload );
+
         public:
             CloneOperationPrivate(CloneOperation* owner);
 
@@ -42,6 +45,8 @@ namespace Git
             void run();
 
         public:
+            RepositoryPrivate::Ptr  mClonedRepo;
+
             QString                 mUrl;
             QString                 mPath;
 

--- a/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
+++ b/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
@@ -21,6 +21,7 @@
 
 #include "libGitWrap/Operations/Private/BaseOperationPrivate.hpp"
 
+#include "libGitWrap/Repository.hpp"
 #include "libGitWrap/Private/RemotePrivate.hpp"
 #include "libGitWrap/Signature.hpp"
 
@@ -46,10 +47,13 @@ namespace Git
             virtual ~BaseRemoteOperationPrivate();
 
         public:
+            Repository      mRepo;
+
+            QString         mRemoteAlias;
             Remote::PrivatePtr      mRemote;
-            QString                 mRefLogMsg;
-            QStringList             mRefSpecs;
-            Signature               mSignature;
+            QString         mRefLogMsg;
+            QStringList     mRefSpecs;
+            Signature       mSignature;
         };
 
 

--- a/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
+++ b/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
@@ -35,6 +35,13 @@ namespace Git
         class BaseRemoteOperationPrivate : public BaseOperationPrivate
         {
         public:
+            static int CB_GetRemote( git_remote** out,
+                                     git_repository* repo,
+                                     const char* name,
+                                     const char* url,
+                                     void* payload );
+
+        public:
             explicit BaseRemoteOperationPrivate(git_remote_callbacks& callbacks, BaseRemoteOperation* owner );
             virtual ~BaseRemoteOperationPrivate();
 

--- a/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
+++ b/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
@@ -35,11 +35,11 @@ namespace Git
         class BaseRemoteOperationPrivate : public BaseOperationPrivate
         {
         public:
-            static int CB_GetRemote( git_remote** out,
-                                     git_repository* repo,
-                                     const char* name,
-                                     const char* url,
-                                     void* payload );
+            static int CB_CreateRemote( git_remote** out,
+                                        git_repository* repo,
+                                        const char* name,
+                                        const char* url,
+                                        void* payload );
 
         public:
             explicit BaseRemoteOperationPrivate(git_remote_callbacks& callbacks, BaseRemoteOperation* owner );

--- a/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
+++ b/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
@@ -22,7 +22,6 @@
 #include "libGitWrap/Operations/Private/BaseOperationPrivate.hpp"
 
 #include "libGitWrap/Repository.hpp"
-#include "libGitWrap/Private/RemotePrivate.hpp"
 #include "libGitWrap/Signature.hpp"
 
 namespace Git
@@ -42,6 +41,10 @@ namespace Git
                                         const char* url,
                                         void* payload );
 
+            static Remote::PrivatePtr lookupRemote( Result& result,
+                                                    Repository::Private* repo,
+                                                    QString& remoteName );
+
         public:
             explicit BaseRemoteOperationPrivate(git_remote_callbacks& callbacks, BaseRemoteOperation* owner );
             virtual ~BaseRemoteOperationPrivate();
@@ -50,7 +53,6 @@ namespace Git
             Repository      mRepo;
 
             QString         mRemoteAlias;
-            Remote::PrivatePtr      mRemote;
             QString         mRefLogMsg;
             QStringList     mRefSpecs;
             Signature       mSignature;

--- a/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
+++ b/libGitWrap/Operations/Private/RemoteOperationsPrivate.hpp
@@ -37,6 +37,12 @@ namespace Git
         public:
             explicit BaseRemoteOperationPrivate(git_remote_callbacks& callbacks, BaseRemoteOperation* owner );
             virtual ~BaseRemoteOperationPrivate();
+
+        public:
+            Remote::PrivatePtr      mRemote;
+            QString                 mRefLogMsg;
+            QStringList             mRefSpecs;
+            Signature               mSignature;
         };
 
 
@@ -50,11 +56,6 @@ namespace Git
 
         public:
             git_remote_callbacks    mRemoteCallbacks;
-
-            Remote::PrivatePtr      mRemote;
-            QString                 mRefLogMsg;
-            QStringList             mRefSpecs;
-            Signature               mSignature;
         };
 
 
@@ -68,6 +69,8 @@ namespace Git
 
         public:
             git_remote_callbacks    mRemoteCallbacks;
+
+            git_push_options        mOpts;
         };
 
     }

--- a/libGitWrap/Operations/RemoteOperations.cpp
+++ b/libGitWrap/Operations/RemoteOperations.cpp
@@ -89,64 +89,64 @@ namespace Git
     {
     }
 
+    Remote BaseRemoteOperation::remote() const
+    {
+        GW_CD( BaseRemoteOperation );
+        return d->mRemote;
+    }
+
+    void BaseRemoteOperation::setRemote(const Remote& remote)
+    {
+        GW_D( BaseRemoteOperation );
+        Q_ASSERT( !isRunning() );
+        d->mRemote = Remote::Private::dataOf<Remote>( remote );
+    }
+
+    const QStringList& BaseRemoteOperation::refSpecs() const
+    {
+        GW_CD( BaseRemoteOperation );
+        return d->mRefSpecs;
+    }
+
+    void BaseRemoteOperation::setRefSpecs(const QStringList& refSprecs)
+    {
+        GW_D( BaseRemoteOperation );
+        Q_ASSERT( !isRunning() );
+        d->mRefSpecs = refSprecs;
+    }
+
+    const Signature& BaseRemoteOperation::signature() const
+    {
+        GW_CD( BaseRemoteOperation );
+        return d->mSignature;
+    }
+
+    void BaseRemoteOperation::setSignature(const Signature& sig)
+    {
+        GW_D( BaseRemoteOperation );
+        Q_ASSERT( !isRunning() );
+        d->mSignature = sig;
+    }
+
+    QString BaseRemoteOperation::refLogMessage() const
+    {
+        GW_CD( BaseRemoteOperation );
+        return d->mRefLogMsg;
+    }
+
+    void BaseRemoteOperation::setRefLogMessage(const QString& msg)
+    {
+        GW_D( BaseRemoteOperation );
+        Q_ASSERT( !isRunning() );
+        d->mRefLogMsg = msg;
+    }
+
 
     //-- FetchOperation -->8
 
     FetchOperation::FetchOperation( QObject* parent )
         : BaseRemoteOperation( *new Private(this), parent )
     {
-    }
-
-    Remote FetchOperation::remote() const
-    {
-        GW_CD( FetchOperation );
-        return d->mRemote;
-    }
-
-    void FetchOperation::setRemote(const Remote& remote)
-    {
-        GW_D( FetchOperation );
-        Q_ASSERT( !isRunning() );
-        d->mRemote = Remote::Private::dataOf<Remote>( remote );
-    }
-
-    const QStringList& FetchOperation::refSpecs() const
-    {
-        GW_CD( FetchOperation );
-        return d->mRefSpecs;
-    }
-
-    void FetchOperation::setRefSpecs(const QStringList& refSprecs)
-    {
-        GW_D( FetchOperation );
-        Q_ASSERT( !isRunning() );
-        d->mRefSpecs = refSprecs;
-    }
-
-    const Signature& FetchOperation::signature() const
-    {
-        GW_CD( FetchOperation );
-        return d->mSignature;
-    }
-
-    void FetchOperation::setSignature(const Signature& sig)
-    {
-        GW_D( FetchOperation );
-        Q_ASSERT( !isRunning() );
-        d->mSignature = sig;
-    }
-
-    QString FetchOperation::refLogMessage() const
-    {
-        GW_CD( FetchOperation );
-        return d->mRefLogMsg;
-    }
-
-    void FetchOperation::setRefLogMessage(const QString& msg)
-    {
-        GW_D( FetchOperation );
-        Q_ASSERT( !isRunning() );
-        d->mRefLogMsg = msg;
     }
 
 

--- a/libGitWrap/Operations/RemoteOperations.cpp
+++ b/libGitWrap/Operations/RemoteOperations.cpp
@@ -31,6 +31,23 @@ namespace Git
 
         //-- BaseRemoteOperationPrivate -->8
 
+        int BaseRemoteOperationPrivate::CB_GetRemote(git_remote** out, git_repository* repo, const char* name, const char* url, void* payload)
+        {
+            // Do not modify "out" here!
+            // It is already configured correctly.
+
+            Q_UNUSED( repo )
+            Q_UNUSED( name )
+            Q_UNUSED( url )
+
+            RemotePrivate* p = static_cast< RemotePrivate* >( payload );
+            Q_ASSERT( p );
+
+            *out = p->mRemote;
+
+            return 0;
+        }
+
         BaseRemoteOperationPrivate::BaseRemoteOperationPrivate(git_remote_callbacks& callbacks, BaseRemoteOperation *owner)
             : BaseOperationPrivate( owner )
         {

--- a/libGitWrap/Operations/RemoteOperations.cpp
+++ b/libGitWrap/Operations/RemoteOperations.cpp
@@ -31,21 +31,20 @@ namespace Git
 
         //-- BaseRemoteOperationPrivate -->8
 
-        int BaseRemoteOperationPrivate::CB_GetRemote(git_remote** out, git_repository* repo, const char* name, const char* url, void* payload)
+        int BaseRemoteOperationPrivate::CB_CreateRemote(git_remote** out, git_repository* repo, const char* name, const char* url, void* payload)
         {
-            // Do not modify "out" here!
-            // It is already configured correctly.
-
-            Q_UNUSED( repo )
-            Q_UNUSED( name )
-            Q_UNUSED( url )
-
-            RemotePrivate* p = static_cast< RemotePrivate* >( payload );
+            BaseRemoteOperationPrivate* p = static_cast< BaseRemoteOperationPrivate* >( payload );
             Q_ASSERT( p );
 
-            *out = p->mRemote;
+            const char* alias = p->mRemoteAlias.isEmpty() ? name : GW_StringFromQt(p->mRemoteAlias);
 
-            return 0;
+            int error = 0;
+            error = git_remote_create(out, repo, alias, url);
+
+            return error;
+        }
+
+
         }
 
         BaseRemoteOperationPrivate::BaseRemoteOperationPrivate(git_remote_callbacks& callbacks, BaseRemoteOperation *owner)

--- a/libGitWrap/Operations/RemoteOperations.cpp
+++ b/libGitWrap/Operations/RemoteOperations.cpp
@@ -17,10 +17,10 @@
  */
 
 #include "RemoteOperations.hpp"
+#include "Private/RemoteOperationsPrivate.hpp"
 
 #include "libGitWrap/Events/Private/GitEventCallbacks.hpp"
 
-#include "Private/RemoteOperationsPrivate.hpp"
 
 
 namespace Git
@@ -68,7 +68,7 @@ namespace Git
 
         void FetchOperationPrivate::run()
         {
-            git_signature* sig = Internal::signature2git(mResult, mSignature);
+            git_signature* sig = signature2git(mResult, mSignature);
 
             if ( mResult )
             {
@@ -89,7 +89,7 @@ namespace Git
 
         void PushOperationPrivate::run()
         {
-            git_signature* sig = Internal::signature2git( mResult, mSignature );
+            git_signature* sig = signature2git( mResult, mSignature );
 
             if ( mResult )
             {

--- a/libGitWrap/Operations/RemoteOperations.cpp
+++ b/libGitWrap/Operations/RemoteOperations.cpp
@@ -145,6 +145,12 @@ namespace Git
     {
     }
 
+    const Repository& BaseRemoteOperation::repository() const
+    {
+        GW_CD( BaseRemoteOperation );
+        return d->mRepo;
+    }
+
     const QStringList& BaseRemoteOperation::refSpecs() const
     {
         GW_CD( BaseRemoteOperation );
@@ -184,20 +190,33 @@ namespace Git
         d->mRefLogMsg = msg;
     }
 
+    /**
+     * @brief           Internal initialization of the repository used for the operation.
+     *
+     * @param repo      the git repository used, when the operation is executed
+     */
+    void BaseRemoteOperation::setRepository(const Repository& repo)
+    {
+        GW_D( BaseRemoteOperation );
+        d->mRepo = repo;
+    }
+
 
     //-- FetchOperation -->8
 
-    FetchOperation::FetchOperation( QObject* parent )
+    FetchOperation::FetchOperation(const Repository& repo, QObject* parent )
         : BaseRemoteOperation( *new Private(this), parent )
     {
+        setRepository( repo );
     }
 
 
     //-- PushOperation -->8
 
-    PushOperation::PushOperation(QObject* parent)
+    PushOperation::PushOperation(const Repository& repo, QObject* parent)
         : BaseRemoteOperation( *new Private(this), parent )
     {
+        setRepository( repo );
     }
 
     unsigned int PushOperation::pbParallellism() const

--- a/libGitWrap/Operations/RemoteOperations.hpp
+++ b/libGitWrap/Operations/RemoteOperations.hpp
@@ -60,9 +60,6 @@ namespace Git
         void updateTip(const QString& branchName, const ObjectId& from, const ObjectId& to);
 
     public:
-        Remote remote() const ;
-        void setRemote(const Remote& remote);
-
         const QStringList& refSpecs() const;
         void setRefSpecs(const QStringList& refSprecs);
 

--- a/libGitWrap/Operations/RemoteOperations.hpp
+++ b/libGitWrap/Operations/RemoteOperations.hpp
@@ -95,6 +95,10 @@ namespace Git
 
     public:
         explicit PushOperation(QObject* parent = 0);
+
+    public:
+        unsigned int pbParallellism() const;
+        void setPBParallelism(unsigned int maxThreads);
     };
 }
 

--- a/libGitWrap/Operations/RemoteOperations.hpp
+++ b/libGitWrap/Operations/RemoteOperations.hpp
@@ -58,18 +58,6 @@ namespace Git
         void error();
         void remoteMessage(const QString& message);
         void updateTip(const QString& branchName, const ObjectId& from, const ObjectId& to);
-    };
-
-
-    class GITWRAP_API FetchOperation : public BaseRemoteOperation
-    {
-        Q_OBJECT
-
-    public:
-        typedef Internal::FetchOperationPrivate Private;
-
-    public:
-        explicit FetchOperation(QObject* parent = 0);
 
     public:
         Remote remote() const ;
@@ -83,6 +71,18 @@ namespace Git
 
         QString refLogMessage() const;
         void setRefLogMessage(const QString& msg);
+    };
+
+
+    class GITWRAP_API FetchOperation : public BaseRemoteOperation
+    {
+        Q_OBJECT
+
+    public:
+        typedef Internal::FetchOperationPrivate Private;
+
+    public:
+        explicit FetchOperation(QObject* parent = 0);
     };
 
 

--- a/libGitWrap/Operations/RemoteOperations.hpp
+++ b/libGitWrap/Operations/RemoteOperations.hpp
@@ -60,6 +60,8 @@ namespace Git
         void updateTip(const QString& branchName, const ObjectId& from, const ObjectId& to);
 
     public:
+        const Repository& repository() const;
+
         const QStringList& refSpecs() const;
         void setRefSpecs(const QStringList& refSprecs);
 
@@ -68,6 +70,9 @@ namespace Git
 
         QString refLogMessage() const;
         void setRefLogMessage(const QString& msg);
+
+    protected:
+        inline void setRepository(const Repository& repo);
     };
 
 
@@ -79,7 +84,7 @@ namespace Git
         typedef Internal::FetchOperationPrivate Private;
 
     public:
-        explicit FetchOperation(QObject* parent = 0);
+        explicit FetchOperation(const Repository& repo, QObject* parent = 0);
     };
 
 
@@ -91,7 +96,7 @@ namespace Git
         typedef Internal::PushOperationPrivate Private;
 
     public:
-        explicit PushOperation(QObject* parent = 0);
+        explicit PushOperation(const Repository& repo, QObject* parent = 0);
 
     public:
         unsigned int pbParallellism() const;

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -96,6 +96,8 @@ namespace Git
             operator QStringList() const;
 
         public:
+            int count() const;
+
             QStringList strings() const;
             void setStrings( const QStringList& strings);
 
@@ -131,6 +133,8 @@ namespace Git
             StrArrayRef& operator=(const StrArrayRef&);
 
         public:
+            int count() const;
+
             QStringList strings() const;
             void setStrings( const QStringList& strings );
 

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -114,7 +114,7 @@ namespace Git
          * @ingroup     GitWrap
          * @brief       Wraps an existing git_strarray for conversion from and to a QStringList.
          */
-        class StrArrayRef
+        class StrArrayRef : public QSharedData
         {
         public:
             StrArrayRef(git_strarray& _a, bool init = false);
@@ -171,8 +171,8 @@ namespace Git
             void init();
 
         private:
-            git_checkout_options&           mOptionsRef;
-            QSharedPointer<StrArrayRef>     mPaths;
+            git_checkout_options&                       mOptionsRef;
+            QExplicitlySharedDataPointer<StrArrayRef>   mPaths;
         };
 
         /**

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -47,9 +47,7 @@ namespace Git
     Remote Remote::create(Result& result, const Repository& repository, const QString& name,
                           const QString& url, const QString& fetchSpec)
     {
-        if (!result) {
-            return Remote();
-        }
+        GW_CHECK_RESULT( result, Remote() );
 
         if (!repository.isValid()) {
             result.setInvalidObject();

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -143,18 +143,11 @@ namespace Git
                                    bool bare,
                                    Result& result )
     {
-        if( !result )
-        {
-            return Repository();
-        }
+        GW_CHECK_RESULT( result, Repository() );
 
         git_repository* repo = NULL;
         result = git_repository_init( &repo, GW_StringFromQt(path), bare );
-
-        if( !result )
-        {
-            return Repository();
-        }
+        GW_CHECK_RESULT( result, Repository() );
 
         return PrivatePtr(new Private(repo));
     }
@@ -190,10 +183,7 @@ namespace Git
                                   const QStringList& ceilingDirs,
                                   Result& result )
     {
-        if( !result )
-        {
-            return QString();
-        }
+        GW_CHECK_RESULT( result, QString() );
 
         git_buf repoPath = {0};
         QByteArray joinedCeilingDirs = GW_EncodeQString( ceilingDirs.join(QChar::fromLatin1(GIT_PATH_LIST_SEPARATOR)) );
@@ -202,8 +192,9 @@ namespace Git
                                           acrossFs, joinedCeilingDirs.constData() );
 
         QString resultPath;
-        if ( result )
+        if ( result ) {
             resultPath = GW_StringToQt(repoPath.ptr);
+        }
 
         git_buf_free( &repoPath );
 
@@ -231,17 +222,12 @@ namespace Git
     Repository Repository::open( const QString& path,
                                  Result& result )
     {
-        if( !result )
-        {
-            return Repository();
-        }
+        GW_CHECK_RESULT( result, Repository() );
+
         git_repository* repo = NULL;
 
         result = git_repository_open( &repo, GW_StringFromQt( path ) );
-        if( !result )
-        {
-            return Repository();
-        }
+        GW_CHECK_RESULT( result, Repository() );
 
         return PrivatePtr(new Private(repo));
     }

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -752,7 +752,7 @@ namespace Git
         Remote::List remotes;
         for (size_t i = 0; i < arr.count; i++) {
             git_remote* remote = NULL;
-            result = git_remote_load(&remote, d->mRepo, arr.strings[i]);
+            result = git_remote_lookup(&remote, d->mRepo, arr.strings[i]);
             if (!result) {
                 git_strarray_free(&arr);
                 return Remote::List();
@@ -804,7 +804,7 @@ namespace Git
         GW_CD_EX_CHECKED(Repository, Remote(), result);
 
         git_remote* remote = NULL;
-        result = git_remote_load( &remote, d->mRepo, GW_StringFromQt(remoteName) );
+        result = git_remote_lookup( &remote, d->mRepo, GW_StringFromQt(remoteName) );
 
         if( !result )
         {

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -763,15 +763,11 @@ namespace Git
     {
         GW_CD_CHECKED(Repository, QStringList(), result);
 
-        git_strarray arr;
-        result = git_remote_list( &arr, d->mRepo );
-        if( !result )
-        {
-            return QStringList();
-        }
+        Internal::StrArray arr;
+        result = git_remote_list( arr, d->mRepo );
+        GW_CHECK_RESULT( result, QStringList() );
 
-        // slFromStrArray frees the git_strarray for us
-        return Internal::slFromStrArray( &arr );
+        return arr.strings();
     }
 
     /**

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -132,8 +132,7 @@ namespace Git
 
         bool shouldIgnore( Result& result, const QString& filePath ) const;
 
-        GW_DEPRECATED
-        RevisionWalker newWalker(Result& result);
+        GW_DEPRECATED RevisionWalker newWalker(Result& result);
 
         QStringList allRemoteNames( Result& result ) const;
         Remote::List allRemotes(Result& result) const;

--- a/libGitWrap/TreeBuilder.cpp
+++ b/libGitWrap/TreeBuilder.cpp
@@ -85,7 +85,7 @@ namespace Git
         GW_D_CHECKED(TreeBuilder, ObjectId(), result);
 
         git_oid oid;
-        result = git_treebuilder_write( &oid, d->repo()->mRepo, d->mBuilder );
+        result = git_treebuilder_write( &oid, d->mBuilder );
 
         if( !result )
         {


### PR DESCRIPTION
This PR implements new operations, available through the recent libgit2 API (>v0.21.3).
- [x] Complete FetchOperation (initialize repository)
- [x] Complete PushOperation (initialize repository)
# Extensions to CloneOperation

Since we now have a common base for all remote operations (Fetch, Push and Clone). Let's make use of that and extend the CloneOperation:
- [x] Implement `git_repository_create_cb` callback to allow customizable repository settings.
- [x] Implement `git_remote_create_cb` callback to allow customizable remote settings.
- [x] Feature: Remote alias is customizable before a clone operation starts. 
