### PR TITLE
Result API Convention

### DIFF
--- a/libGitWrap/Base.cpp
+++ b/libGitWrap/Base.cpp
@@ -68,13 +68,13 @@ namespace Git
          *
          * @param[in]       d   The BasePrivate to check.
          *
-         * @return          `true`, if this object can be treated as vaild.
+         * @return          `true`, if this object can be treated as valid.
          *
          */
         bool BasePrivate::isValid(Result& r, const BasePrivate* d)
         {
-            if (Q_LIKELY(d)) {
-                return d->isValidObject(r);
+            if ( Q_LIKELY(d) ) {
+                return d->isValidObject( r );
             }
             r.setInvalidObject();
             return false;

--- a/libGitWrap/Commit.cpp
+++ b/libGitWrap/Commit.cpp
@@ -299,42 +299,16 @@ namespace Git
         return result && id() == commit.id();
     }
 
-    Signature Commit::author( Result& result ) const
-    {
-        return author();
-    }
-
-    Signature Commit::committer( Result& result ) const
-    {
-        return committer();
-    }
-
-    QString Commit::message( Result& result ) const
-    {
-        return message();
-    }
-
-    QString Commit::shortMessage( Result& result ) const
-    {
-        return shortMessage();
-    }
-
     Signature Commit::author() const
     {
         GW_CD(Commit);
-        if (!d) {
-            return Signature();
-        }
-        return Internal::git2Signature(git_commit_author(d->o()));
+        return d ? Internal::git2Signature( git_commit_author(d->o()) ) : Signature();
     }
 
     Signature Commit::committer() const
     {
         GW_CD(Commit);
-        if (!d) {
-            return Signature();
-        }
-        return Internal::git2Signature(git_commit_committer(d->o()));
+        return d ? Internal::git2Signature( git_commit_committer(d->o()) ) : Signature();
     }
 
     QString Commit::message() const

--- a/libGitWrap/Commit.cpp
+++ b/libGitWrap/Commit.cpp
@@ -97,7 +97,7 @@ namespace Git
     Commit Commit::create(Result &result, Repository& repo, const Tree &tree, const QString &message,
                           const Signature &author, const Signature &committer, const CommitList &parents)
     {
-        if (!result) return Commit();
+        GW_CHECK_RESULT( result, Commit() );
         if (!repo.isValid() || !tree.isValid())
         {
             result.setInvalidObject();
@@ -146,7 +146,7 @@ namespace Git
     Commit Commit::create(Result &result, Repository& repo, const Tree &tree, const QString &message,
                           const Signature &author, const Signature &committer, const ObjectIdList &parents)
     {
-        if (!result) return Commit();
+        GW_CHECK_RESULT( result, Commit() );
         if (!repo.isValid() || !tree.isValid())
         {
             result.setInvalidObject();
@@ -216,6 +216,7 @@ namespace Git
 
     Commit Commit::parentCommit(Result& result, unsigned int index) const
     {
+        GW_CHECK_RESULT( result, Commit() );
         GW_CD_CHECKED(Commit, Commit(), result);
         git_commit* gitparent = NULL;
 
@@ -229,6 +230,7 @@ namespace Git
 
     ObjectId Commit::parentCommitId(Result& result, unsigned int index) const
     {
+        GW_CHECK_RESULT( result, ObjectId() );
         GW_CD_CHECKED(Commit, ObjectId(), result)
 
         if(numParentCommits() > index) {
@@ -243,6 +245,7 @@ namespace Git
 
     CommitList Commit::parentCommits( Result& result ) const
     {
+        GW_CHECK_RESULT( result, CommitList() );
         GW_CD_CHECKED(Commit, CommitList(), result)
         CommitList objs;
 
@@ -376,6 +379,7 @@ namespace Git
 
     DiffList Commit::diffFromParent(Result& result, unsigned int index)
     {
+        GW_CHECK_RESULT( result, DiffList() );
         GW_CD_CHECKED(Commit, DiffList(), result)
 
         Commit parentObjCommit = parentCommit( result, index );
@@ -386,6 +390,7 @@ namespace Git
 
     DiffList Commit::diffFromAllParents( Result& result )
     {
+        GW_CHECK_RESULT( result, DiffList() );
         GW_CD_CHECKED(Commit, DiffList(), result)
 
         if (numParentCommits() == 0) {

--- a/libGitWrap/Commit.cpp
+++ b/libGitWrap/Commit.cpp
@@ -183,7 +183,6 @@ namespace Git
 
     Tree Commit::tree( Result& result ) const
     {
-        GW_CHECK_RESULT( result, Tree() );
         GW_CD_CHECKED(Commit, Tree(), result);
         git_tree* tree = NULL;
 
@@ -195,14 +194,12 @@ namespace Git
 
     ObjectId Commit::treeId( Result& result ) const
     {
-        GW_CHECK_RESULT( result, ObjectId() );
         GW_CD_CHECKED(Commit, ObjectId(), result);
         return Private::oid2sha(git_commit_tree_id(d->o()));
     }
 
     ObjectIdList Commit::parentCommitIds( Result& result ) const
     {
-        GW_CHECK_RESULT( result, ObjectIdList() );
         GW_CD_CHECKED(Commit, ObjectIdList(), result);
 
         const git_commit* commit = d->o();
@@ -216,7 +213,6 @@ namespace Git
 
     Commit Commit::parentCommit(Result& result, unsigned int index) const
     {
-        GW_CHECK_RESULT( result, Commit() );
         GW_CD_CHECKED(Commit, Commit(), result);
         git_commit* gitparent = NULL;
 
@@ -230,7 +226,6 @@ namespace Git
 
     ObjectId Commit::parentCommitId(Result& result, unsigned int index) const
     {
-        GW_CHECK_RESULT( result, ObjectId() );
         GW_CD_CHECKED(Commit, ObjectId(), result)
 
         if(numParentCommits() > index) {
@@ -245,7 +240,6 @@ namespace Git
 
     CommitList Commit::parentCommits( Result& result ) const
     {
-        GW_CHECK_RESULT( result, CommitList() );
         GW_CD_CHECKED(Commit, CommitList(), result)
         CommitList objs;
 
@@ -379,7 +373,6 @@ namespace Git
 
     DiffList Commit::diffFromParent(Result& result, unsigned int index)
     {
-        GW_CHECK_RESULT( result, DiffList() );
         GW_CD_CHECKED(Commit, DiffList(), result)
 
         Commit parentObjCommit = parentCommit( result, index );
@@ -390,7 +383,6 @@ namespace Git
 
     DiffList Commit::diffFromAllParents( Result& result )
     {
-        GW_CHECK_RESULT( result, DiffList() );
         GW_CD_CHECKED(Commit, DiffList(), result)
 
         if (numParentCommits() == 0) {

--- a/libGitWrap/Commit.hpp
+++ b/libGitWrap/Commit.hpp
@@ -72,11 +72,6 @@ namespace Git
         bool isChildOf( Result& result, const Git::Commit& parent ) const;
         bool isEqual( Result& result, const Git::Commit& commit ) const;
 
-        GW_DEPRECATED Signature author( Result& result ) const;
-        GW_DEPRECATED Signature committer( Result& result ) const;
-        GW_DEPRECATED QString message( Result& result ) const;
-        GW_DEPRECATED QString shortMessage( Result& result ) const;
-
         Signature author() const;
         Signature committer() const;
 
@@ -86,6 +81,47 @@ namespace Git
         DiffList diffFromParent( Result& result, unsigned int index );
         DiffList diffFromAllParents( Result& result );
 
+
+    public:
+        // -- DEPRECATED FUNCTIONS BEGIN --8>
+
+        /**
+         * @brief       Deprecated: Commit::author
+         * @deprecated  Use @ref Commit::author() instead.
+         */
+        GW_DEPRECATED inline Signature author( Result& result ) const
+        {
+            return author();
+        }
+
+        /**
+         * @brief       Deprecated: Commit::committer
+         * @deprecated  Use @ref Commit::committer() instead.
+         */
+        GW_DEPRECATED inline Signature committer( Result& result ) const
+        {
+            return committer();
+        }
+
+        /**
+         * @brief       Deprecated: Commit::message
+         * @deprecated  Use @ref Commit::message() instead.
+         */
+        GW_DEPRECATED inline QString message( Result& result ) const
+        {
+            return message();
+        }
+
+        /**
+         * @brief       Deprecated: Commit::shortMessage
+         * @deprecated  Use @ref Commit::shortMessage() instead.
+         */
+        GW_DEPRECATED inline QString shortMessage( Result& result ) const
+        {
+            return shortMessage();
+        }
+
+        // <8-- DEPRECATED FUNCTIONS END --
     };
 
     template<>

--- a/libGitWrap/Config.cpp
+++ b/libGitWrap/Config.cpp
@@ -41,12 +41,6 @@ namespace Git
 
     GW_PRIVATE_IMPL(Config, Base)
 
-    QString Config::globalFilePath()
-    {
-        Result r;
-        return globalFilePath( r );
-    }
-
     QString Config::globalFilePath(Result &result)
     {
         GW_CHECK_RESULT( result, QString() );
@@ -58,12 +52,6 @@ namespace Git
         return path.toString();
     }
 
-    QString Config::userFilePath()
-    {
-        Result r;
-        return userFilePath( r );
-    }
-
     QString Config::userFilePath( Result& result)
     {
         GW_CHECK_RESULT( result, QString() );
@@ -73,12 +61,6 @@ namespace Git
         GW_CHECK_RESULT( result, QString() );
 
         return path.toString();
-    }
-
-    Config Config::global()
-    {
-        Result r;
-        return global( r );
     }
 
     Config Config::global(Result &result)
@@ -97,12 +79,6 @@ namespace Git
         return PrivatePtr(new Private(cfg));
     }
 
-    Config Config::user()
-    {
-        Result r;
-        return user(r);
-    }
-
     Config Config::user(Result &result)
     {
         GW_CHECK_RESULT( result, Config() );
@@ -119,12 +95,6 @@ namespace Git
         return PrivatePtr(new Private(cfg));
     }
 
-    Config Config::file( const QString& fileName )
-    {
-        Result r;
-        return file( r, fileName );
-    }
-
     Config Config::file( Result& result, const QString& fileName )
     {
         GW_CHECK_RESULT( result, Config() );
@@ -136,12 +106,6 @@ namespace Git
         return PrivatePtr(new Private(cfg));
     }
 
-    Config Config::create()
-    {
-        Result r;
-        return create( r );
-    }
-
     Config Config::create(Result& result)
     {
         GW_CHECK_RESULT( result, Config() );
@@ -151,12 +115,6 @@ namespace Git
         GW_CHECK_RESULT( result, Config() );
 
         return PrivatePtr(new Private(cfg));
-    }
-
-    bool Config::addFile(const QString& fileName, int priority)
-    {
-        Result r;
-        return addFile( r, fileName, priority );
     }
 
     bool Config::addFile(Result& result, const QString& fileName, int priority)
@@ -179,12 +137,6 @@ namespace Git
         cv->insert( GW_StringToQt( entry->name ),
                     GW_StringToQt( entry->value ) );
         return 0;
-    }
-
-    ConfigValues Config::values() const
-    {
-        Result r;
-        return values( r );
     }
 
     ConfigValues Config::values(Result &result) const

--- a/libGitWrap/Config.cpp
+++ b/libGitWrap/Config.cpp
@@ -49,16 +49,13 @@ namespace Git
 
     QString Config::globalFilePath(Result &result)
     {
-        QString filePath;
+        GW_CHECK_RESULT( result, QString() );
+
         Internal::Buffer path;
-
         result = git_config_find_system( path );
-        if( result )
-        {
-            filePath = path.toString();
-        }
+        GW_CHECK_RESULT( result, QString() );
 
-        return filePath;
+        return path.toString();
     }
 
     QString Config::userFilePath()
@@ -69,16 +66,13 @@ namespace Git
 
     QString Config::userFilePath( Result& result)
     {
-        QString filePath;
+        GW_CHECK_RESULT( result, QString() );
+
         Internal::Buffer path;
-
         result = git_config_find_global( path );
-        if( result )
-        {
-            filePath = path.toString();
-        }
+        GW_CHECK_RESULT( result, QString() );
 
-        return filePath;
+        return path.toString();
     }
 
     Config Config::global()
@@ -89,16 +83,18 @@ namespace Git
 
     Config Config::global(Result &result)
     {
+        GW_CHECK_RESULT( result, Config() );
+
         Internal::Buffer path;
         git_config* cfg = NULL;
 
         result = git_config_find_system( path );
-        if( result )
-        {
-            result = git_config_open_ondisk( &cfg, path );
-        }
+        GW_CHECK_RESULT( result, Config() );
 
-        return result ? PrivatePtr(new Private(cfg)) : Config();
+        result = git_config_open_ondisk( &cfg, path );
+        GW_CHECK_RESULT( result, Config() );
+
+        return PrivatePtr(new Private(cfg));
     }
 
     Config Config::user()
@@ -109,16 +105,18 @@ namespace Git
 
     Config Config::user(Result &result)
     {
+        GW_CHECK_RESULT( result, Config() );
+
         Internal::Buffer path;
         git_config* cfg = NULL;
 
         result = git_config_find_global( path );
-        if ( result )
-        {
-            result = git_config_open_ondisk( &cfg, path );
-        }
+        GW_CHECK_RESULT( result, Config() );
 
-        return result ? PrivatePtr(new Private(cfg)) : Config();
+        result = git_config_open_ondisk( &cfg, path );
+        GW_CHECK_RESULT( result, Config() );
+
+        return PrivatePtr(new Private(cfg));
     }
 
     Config Config::file( const QString& fileName )
@@ -129,13 +127,11 @@ namespace Git
 
     Config Config::file( Result& result, const QString& fileName )
     {
+        GW_CHECK_RESULT( result, Config() );
         git_config* cfg = NULL;
 
         result = git_config_open_ondisk( &cfg, fileName.toLocal8Bit().constData() );
-        if( !result )
-        {
-            return Config();
-        }
+        GW_CHECK_RESULT( result, Config() );
 
         return PrivatePtr(new Private(cfg));
     }
@@ -148,13 +144,11 @@ namespace Git
 
     Config Config::create(Result& result)
     {
+        GW_CHECK_RESULT( result, Config() );
+
         git_config* cfg = NULL;
         result = git_config_new( &cfg );
-
-        if( !result )
-        {
-            return Config();
-        }
+        GW_CHECK_RESULT( result, Config() );
 
         return PrivatePtr(new Private(cfg));
     }
@@ -198,6 +192,8 @@ namespace Git
         GW_CD(Config);
         ConfigValues values;
         result = git_config_foreach( d->mCfg, &read_config_cb, (void*) &values );
+        GW_CHECK_RESULT( result, ConfigValues() );
+
         return values;
     }
 

--- a/libGitWrap/Config.cpp
+++ b/libGitWrap/Config.cpp
@@ -119,9 +119,9 @@ namespace Git
 
     bool Config::addFile(Result& result, const QString& fileName, int priority)
     {
-        GW_D(Config);
+        GW_D_CHECKED( Config, false, result );
 
-        if( !d || fileName.isEmpty() )
+        if( fileName.isEmpty() )
         {
             return false;
         }
@@ -141,7 +141,8 @@ namespace Git
 
     ConfigValues Config::values(Result &result) const
     {
-        GW_CD(Config);
+        GW_CD_CHECKED( Config, ConfigValues(), result );
+
         ConfigValues values;
         result = git_config_foreach( d->mCfg, &read_config_cb, (void*) &values );
         GW_CHECK_RESULT( result, ConfigValues() );

--- a/libGitWrap/Config.hpp
+++ b/libGitWrap/Config.hpp
@@ -22,6 +22,12 @@
 
 #include "libGitWrap/Base.hpp"
 
+// -- DEPRECATED INCLUDES BEGIN --8>
+
+#include "libGitWrap/Result.hpp"
+
+// <8-- DEPRECATED INCLUDES END --
+
 namespace Git
 {
 
@@ -42,27 +48,104 @@ namespace Git
         GW_PRIVATE_DECL(Config, Base, public)
 
     public:
-        GW_DEPRECATED bool addFile( const QString& fileName, int priority );
         bool addFile( Result &result, const QString& fileName, int priority );
 
-        GW_DEPRECATED ConfigValues values() const;
         ConfigValues values( Result& result ) const;
 
     public:
-        GW_DEPRECATED static QString globalFilePath();
         static QString globalFilePath( Result& result );
-        GW_DEPRECATED static QString userFilePath();
         static QString userFilePath( Result& result );
 
-        GW_DEPRECATED static Config global();
         static Config global( Result &result );
-        GW_DEPRECATED static Config user();
         static Config user( Result &result );
-        GW_DEPRECATED static Config file( const QString& fileName );
         static Config file( Result& result, const QString& fileName );
 
-        GW_DEPRECATED static Config create();
         static Config create( Result &result );
+
+    public:
+        // -- DEPRECATED FUNCTION BEGIN --8>
+
+        /**
+         * @brief Deprecated: Config::addFile
+         * @deprecated Use @ref Config::addFile( Result &result, const QString& fileName, int priority ) instead.
+         */
+        GW_DEPRECATED inline bool addFile( const QString& fileName, int priority )
+        {
+            Result r;
+            return addFile( r, fileName, priority );
+        }
+
+        /**
+         * @brief Deprecated: Config::values
+         * @deprecated Use @ref Config::values( Result &result ) instead.
+         */
+        GW_DEPRECATED inline ConfigValues values() const
+        {
+            Result r;
+            return values( r );
+        }
+
+        /**
+         * @brief Deprecated: Config::globalFilePath
+         * @deprecated Use Config::globalFilePath( Result &result ) instead.
+         */
+        GW_DEPRECATED static QString globalFilePath()
+        {
+            Result r;
+            return globalFilePath( r );
+        }
+
+        /**
+         * @brief Deprecated: Config::userFilePath
+         * @deprecated Use Config::userFilePath( Result &result ) instead.
+         */
+        GW_DEPRECATED static QString userFilePath()
+        {
+            Result r;
+            return userFilePath( r );
+        }
+
+        /**
+         * @brief Deprecated: Config::global
+         * @deprecated Use Config::global( Result &result ) instead.
+         */
+        GW_DEPRECATED static Config global()
+        {
+            Result r;
+            return global( r );
+        }
+
+        /**
+         * @brief Deprecated: Config::user
+         * @deprecated Use Config::user( Result &result ) instead.
+         */
+        GW_DEPRECATED static Config user()
+        {
+            Result r;
+            return user(r);
+        }
+
+        /**
+         * @brief Deprecated: Config::file
+         * @deprecated Use Config::file( Result &result, const QString& fileName ) instead.
+         */
+        GW_DEPRECATED static Config file( const QString& fileName )
+        {
+            Result r;
+            return file( r, fileName );
+        }
+
+        /**
+         * @brief Deprecated: Config::create
+         * @deprecated Use Config::create( Result &result ) instead.
+         */
+        GW_DEPRECATED static Config create()
+        {
+            Result r;
+            return create( r );
+        }
+
+        // <8-- DEPRECATED FUNCTIONS END --
     };
 
 }

--- a/libGitWrap/Config.hpp
+++ b/libGitWrap/Config.hpp
@@ -63,7 +63,7 @@ namespace Git
         static Config create( Result &result );
 
     public:
-        // -- DEPRECATED FUNCTION BEGIN --8>
+        // -- DEPRECATED FUNCTIONS BEGIN --8>
 
         /**
          * @brief Deprecated: Config::addFile

--- a/libGitWrap/Events/Private/GitEventCallbacks.cpp
+++ b/libGitWrap/Events/Private/GitEventCallbacks.cpp
@@ -214,7 +214,7 @@ namespace Git
             ICheckoutEvents* events = static_cast< ICheckoutEvents* >( payload );
             Q_ASSERT( events );
 
-            debugEvents( "checkout progress: %d / %d", completed_steps, total_steps );
+            debugEvents( "checkout progress: %lu / %lu", completed_steps, total_steps );
 
             if (events) {
                 events->checkoutProgress( GW_StringToQt(path), total_steps, completed_steps );

--- a/libGitWrap/Index.cpp
+++ b/libGitWrap/Index.cpp
@@ -155,9 +155,7 @@ namespace Git
      */
     Index Index::openPath(Result& result, const QString& path)
     {
-        if (!result) {
-            return Index();
-        }
+        GW_CHECK_RESULT( result, Index() );
 
         git_index* index = NULL;
         result = git_index_open( &index, GW_StringFromQt(path) );

--- a/libGitWrap/Object.cpp
+++ b/libGitWrap/Object.cpp
@@ -80,11 +80,6 @@ namespace Git
         }
     }
 
-    ObjectId Object::id(Result& result) const
-    {
-        return id();
-    }
-
     ObjectId Object::id() const
     {
         GW_CD(Object);
@@ -159,10 +154,5 @@ namespace Git
         GW_CD(Object);
         return d && d->objectType() == otBlob;
     }
-
-    Tree   Object::asTree  (Result& result) const { return asTree();   }
-    Commit Object::asCommit(Result& result) const { return asCommit(); }
-    Blob   Object::asBlob  (Result& result) const { return asBlob();   }
-    Tag    Object::asTag   (Result& result) const { return asTag();    }
 
 }

--- a/libGitWrap/Object.hpp
+++ b/libGitWrap/Object.hpp
@@ -21,6 +21,7 @@
 
 #include "libGitWrap/ObjectId.hpp"
 
+
 namespace Git
 {
 
@@ -50,8 +51,6 @@ namespace Git
          * @return the object's id (OID)
          */
         ObjectId id() const;
-
-        GW_DEPRECATED ObjectId id( Result& result ) const;
 
         /**
          * @brief Converts a generic object into a Git tree object.
@@ -117,20 +116,6 @@ namespace Git
          * @return true or false
          */
         bool isBlob() const;
-
-        GW_DEPRECATED bool isTree   (Result& result) const { return isTree();   }
-        GW_DEPRECATED bool isTag    (Result& result) const { return isTag();    }
-        GW_DEPRECATED bool isCommit (Result& result) const { return isCommit(); }
-        GW_DEPRECATED bool isBlob   (Result& result) const { return isBlob();   }
-
-        GW_DEPRECATED Tree   asTree  (Result& result) const;
-        GW_DEPRECATED Commit asCommit(Result& result) const;
-        GW_DEPRECATED Blob   asBlob  (Result& result) const;
-        GW_DEPRECATED Tag    asTag   (Result& result) const;
-
-        template< class T >
-        GW_DEPRECATED T as(Result& result) const { return as<T>(); }
-
     };
 
 }

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -399,10 +399,11 @@ namespace Git
 // -- pimpl helper macro definitions ->8
 
 #define GW__CHECK(returns, result) \
-    if (!Private::isValid(result, d)) { return returns; }
+    if (!Internal::BasePrivate::isValid(result, d)) { return returns; }
 
 #define GW__EX_CHECK(returns, result) \
-    if (!Private::isValid(result, d.constData())) { return returns; }
+    if (!Internal::BasePrivate::isValid(result, d.constData())) { return returns; }
+
 
 #define GW_D(CLASS) \
     Private* d = static_cast<Private*>(mData.data()); \

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -399,10 +399,10 @@ namespace Git
 // -- pimpl helper macro definitions ->8
 
 #define GW__CHECK(returns, result) \
-    if (!Private::isValid(result, d)) { result.setInvalidObject(); return returns; }
+    if (!Private::isValid(result, d)) { return returns; }
 
 #define GW__EX_CHECK(returns, result) \
-    if (!Private::isValid(result, d.constData())) { result.setInvalidObject(); return returns; }
+    if (!Private::isValid(result, d.constData())) { return returns; }
 
 #define GW_D(CLASS) \
     Private* d = static_cast<Private*>(mData.data()); \

--- a/libGitWrap/Private/GitWrapPrivate.hpp
+++ b/libGitWrap/Private/GitWrapPrivate.hpp
@@ -419,6 +419,11 @@ namespace Git
 #define GW_CD_EX(CLASS) \
     const CLASS::PrivatePtr d(static_cast<CLASS::Private*>(mData.data()))
 
+
+#define GW_CD_CHECKED(CLASS, returns, result) \
+    GW_CD(CLASS); \
+    GW__CHECK(returns, result)
+
 #define GW_CD_EX_CHECKED(CLASS, returns, result) \
     GW_CD_EX(CLASS); \
     GW__EX_CHECK(returns, result)
@@ -430,9 +435,5 @@ namespace Git
 #define GW_D_EX_CHECKED(CLASS, returns, result) \
     GW_D_EX(CLASS); \
     GW__EX_CHECK(returns, result)
-
-#define GW_CD_CHECKED(CLASS, returns, result) \
-    GW_CD(CLASS); \
-    GW__CHECK(returns, result)
 
 #endif

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -304,7 +304,6 @@ namespace Git
 
     Reference Reference::resolved( Result& result ) const
     {
-        GW_CHECK_RESULT( result, Reference() );
         GW_CD_CHECKED(Reference, Reference(), result);
 
         git_reference* ref;
@@ -360,7 +359,6 @@ namespace Git
 
     Object Reference::peeled(Result& result, ObjectType ot) const
     {
-        GW_CHECK_RESULT( result, Object() );
         GW_CD_CHECKED(Reference, Object(), result);
 
         git_object* o = NULL;
@@ -382,7 +380,6 @@ namespace Git
      */
     void Reference::destroy(Result& result)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(Reference, void(), result);
 
         result = git_reference_delete(d->reference);
@@ -400,7 +397,6 @@ namespace Git
 
     void Reference::move(Result &result, const Commit &target)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(Reference, void(), result);
 
         ObjectId targetId = target.id();
@@ -421,7 +417,6 @@ namespace Git
 
     void Reference::rename(Result &result, const QString &newName, bool force)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(Reference, void(), result);
 
         git_reference* newRef = NULL;
@@ -446,7 +441,6 @@ namespace Git
      */
     void Reference::setAsDetachedHEAD(Result& result) const
     {
-        GW_CHECK_RESULT( result, void() );
         GW_CD_CHECKED(Reference, void(), result);
 
         repository().setDetachedHEAD( result, peeled<Commit>(result).id() );
@@ -454,7 +448,6 @@ namespace Git
 
     void Reference::updateHEAD(Result &result) const
     {
-        GW_CHECK_RESULT( result, void() )
         GW_CD_CHECKED(Reference, void(), result);
 
         if (git_reference_is_branch(d->reference)) {

--- a/libGitWrap/Reference.cpp
+++ b/libGitWrap/Reference.cpp
@@ -93,7 +93,7 @@ namespace Git
         {
             // don't check r here! it will be correctly set.
 
-            if (wasDeleted) {
+            if ( wasDeleted ) {
                 r.setError("Tried to access a destroyed reference.", GIT_EUSER);
                 return false;
             }

--- a/libGitWrap/Reference.hpp
+++ b/libGitWrap/Reference.hpp
@@ -59,10 +59,6 @@ namespace Git
 
         RefName nameAnalyzer() const;
 
-        GW_DEPRECATED ReferenceTypes type(Result& result) const   { return type(); }
-        GW_DEPRECATED ObjectId objectId(Result& result) const     { return objectId(); }
-        GW_DEPRECATED QString target(Result& result) const        { return target(); }
-
         ReferenceTypes type() const;
         ObjectId objectId() const;
         QString target() const;
@@ -105,6 +101,28 @@ namespace Git
     public:
         operator ParentProviderPtr() const;
         operator TreeProviderPtr() const;
+
+    public:
+       // -- DEPRECATED FUNCTIONS BEGIN --8>
+       /**
+        * @brief        Deprecated: Reference::type
+        * @deprecated   Use @ref Reference::type() instead.
+        */
+       GW_DEPRECATED inline ReferenceTypes type(Result& result) const   { return type(); }
+
+       /**
+        * @brief        Deprecated: Reference::objectId
+        * @deprecated   Use @ref Reference::objectId() instead.
+        */
+       GW_DEPRECATED inline ObjectId objectId(Result& result) const     { return objectId(); }
+
+       /**
+        * @brief        Deprecated: Reference::target
+        * @deprecated   Use @ref Reference::target() instead.
+        */
+       GW_DEPRECATED inline QString target(Result& result) const        { return target(); }
+
+       // <8-- DEPRECATED FUNCTIONS END --
     };
 
     template< class T >

--- a/libGitWrap/Remote.cpp
+++ b/libGitWrap/Remote.cpp
@@ -159,16 +159,6 @@ namespace Git
         return result;
     }
 
-    bool Remote::isValidUrl( const QString& url )
-    {
-        return isSupportedUrl( url );
-    }
-
-    bool Remote::isSupportedUrl( const QString& url )
-    {
-        return true;
-    }
-
     bool Remote::connect(Result& result, bool forFetch)
     {
         GW_D_CHECKED(Remote, false, result);

--- a/libGitWrap/Remote.hpp
+++ b/libGitWrap/Remote.hpp
@@ -62,13 +62,27 @@ namespace Git
         QVector<RefSpec> fetchSpecs() const;
         QVector<RefSpec> pushSpecs() const;
 
-        GW_DEPRECATED static bool isValidUrl(const QString& url);
-        GW_DEPRECATED static bool isSupportedUrl(const QString& url);
-
         bool connect(Result& result, bool forFetch);
         void disconnect(Result& result);
         bool download(Result& result, const QStringList &refspecs = QStringList());
         bool updateTips(Result& result);
+
+    public:
+        // -- DEPRECATED FUNCTIONS BEGIN --8>
+
+        /**
+         * @brief       Deprecated: Remote::isValidUrl
+         * @deprecated  Obsolete method. Always returns true.
+         */
+        GW_DEPRECATED static bool isValidUrl(const QString& url) { return true; }
+
+        /**
+         * @brief       Deprecated: Remote::isSupportedUrl()
+         * @deprecated  Obsolete method. Always returns true.
+         */
+        GW_DEPRECATED static bool isSupportedUrl(const QString& url) { return true; }
+
+        // <8-- DEPRECATED FUNcTIONS END --
     };
 
 }

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -294,7 +294,6 @@ namespace Git
      */
     Index Repository::index( Result& result )
     {
-        GW_CHECK_RESULT( result, Index() );
         GW_D_CHECKED(Repository, Index(), result);
 
         if( isBare() ) {
@@ -330,7 +329,6 @@ namespace Git
      */
     Git::StatusFlags Repository::status(Result &result, const QString &fileName) const
     {
-        GW_CHECK_RESULT( result, FileInvalidStatus );
         GW_CD_CHECKED(Repository, FileInvalidStatus, result);
 
         unsigned int status = GIT_STATUS_CURRENT;
@@ -342,7 +340,6 @@ namespace Git
 
     StatusHash Repository::status(Result &result) const
     {
-        GW_CHECK_RESULT( result, StatusHash() );
         GW_CD_CHECKED(Repository, StatusHash(), result);
 
         git_status_options opt = GIT_STATUS_OPTIONS_INIT;
@@ -369,7 +366,6 @@ namespace Git
      */
     QStringList Repository::allReferenceNames( Result& result )
     {
-        GW_CHECK_RESULT( result, QStringList() );
         GW_D_CHECKED(Repository, QStringList(), result);
 
         git_strarray arr;
@@ -381,7 +377,6 @@ namespace Git
 
     ReferenceList Repository::allReferences(Result &result)
     {
-        GW_CHECK_RESULT( result, ReferenceList() );
         GW_D_CHECKED(Repository, ReferenceList(), result);
 
         Internal::cb_append_reference_data data = { d };
@@ -427,7 +422,6 @@ namespace Git
 
     ResolvedRefs Repository::allResolvedRefs( Result& result )
     {
-        GW_CHECK_RESULT( result, ResolvedRefs() );
         GW_CD_CHECKED(Repository, ResolvedRefs(), result);
 
         Internal::cb_enum_resolvedrefs_data data;
@@ -464,7 +458,6 @@ namespace Git
 
     QStringList Repository::branchNames(Result& result, bool local, bool remote)
     {
-        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         QStringList sl;
@@ -508,7 +501,6 @@ namespace Git
 
     bool Repository::renameBranch(Result& result, const QString& oldName, const QString& newName, bool force)
     {
-        GW_CHECK_RESULT( result, false );
         GW_CD_CHECKED(Repository, false, result);
 
         git_reference* ref = NULL;
@@ -542,7 +534,6 @@ namespace Git
 
     QStringList Repository::allTagNames( Result& result )
     {
-        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         git_strarray arr;
@@ -608,7 +599,6 @@ namespace Git
 
     Reference Repository::HEAD( Result& result ) const
     {
-        GW_CHECK_RESULT( result, Reference() );
         GW_CD_EX_CHECKED(Repository, Reference(), result);
 
         git_reference* refHead = NULL;
@@ -634,7 +624,6 @@ namespace Git
 
     Object Repository::lookup( Result& result, const ObjectId& id, ObjectType ot )
     {
-        GW_CHECK_RESULT( result, Object() );
         GW_D_EX_CHECKED(Repository, Object(), result);
 
         git_object* obj = NULL;
@@ -693,7 +682,6 @@ namespace Git
 
     bool Repository::shouldIgnore(Result& result, const QString& filePath) const
     {
-        GW_CHECK_RESULT( result, false );
         GW_CD_CHECKED(Repository, false, result);
 
         int ignore = 0;
@@ -717,7 +705,6 @@ namespace Git
      */
     Remote::List Repository::allRemotes(Result& result) const
     {
-        GW_CHECK_RESULT( result, Remote::List() );
         GW_CD_EX_CHECKED(Repository, Remote::List(), result);
 
         git_strarray arr;
@@ -752,7 +739,6 @@ namespace Git
      */
     QStringList Repository::allRemoteNames( Result& result ) const
     {
-        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         Internal::StrArray arr;
@@ -775,7 +761,6 @@ namespace Git
      */
     Remote Repository::remote(Result& result, const QString& remoteName) const
     {
-        GW_CHECK_RESULT( result, Remote() );
         GW_CD_EX_CHECKED(Repository, Remote(), result);
 
         git_remote* remote = NULL;
@@ -812,7 +797,6 @@ namespace Git
 
     DiffList Repository::diffIndexToWorkingDir( Result& result )
     {
-        GW_CHECK_RESULT( result, DiffList() );
         GW_D_EX_CHECKED(Repository, DiffList(), result);
 
         git_diff* diff = NULL;
@@ -855,7 +839,6 @@ namespace Git
 
     Submodule::List Repository::submodules( Result& result )
     {
-        GW_CHECK_RESULT( result, Submodule::List() );
         GW_D_CHECKED(Repository, Submodule::List(), result);
         Internal::cb_enum_submodules_t data = { d };
 
@@ -867,7 +850,6 @@ namespace Git
 
     QStringList Repository::submoduleNames(Result& result) const
     {
-        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         QStringList names;
@@ -880,7 +862,6 @@ namespace Git
 
     Submodule Repository::submodule(Result& result, const QString& name) const
     {
-        GW_CHECK_RESULT( result, Submodule() );
         GW_CD_EX_CHECKED(Repository, Submodule(), result);
 
         if (submoduleNames(result).contains(name)) {
@@ -910,7 +891,6 @@ namespace Git
      */
     bool Repository::detachHead(Result& result)
     {
-        GW_CHECK_RESULT( result, false );
         GW_D_CHECKED(Repository, false, result);
 
         result = git_repository_detach_head( d->mRepo, NULL, NULL );
@@ -930,7 +910,6 @@ namespace Git
      */
     void Repository::setHEAD(Result& result, const QString& branchName)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(Repository, void(), result);
 
         result = git_repository_set_head( d->mRepo, GW_StringFromQt(branchName), NULL, NULL );
@@ -967,7 +946,6 @@ namespace Git
      */
     void Repository::setDetachedHEAD(Result& result, const ObjectId& sha)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(Repository, void(), result);
 
         result = git_repository_set_head_detached( d->mRepo, Private::sha(sha), NULL, NULL);
@@ -1011,7 +989,6 @@ namespace Git
 
     Reference Repository::reference(Result& result, const QString& refName, bool dwim)
     {
-        GW_CHECK_RESULT( result, Reference() );
         GW_D_CHECKED(Repository, Reference(), result);
 
         //GW_D_EX_CHECKED(Repository, Reference(), result);

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -139,9 +139,9 @@ namespace Git
      *
      * @see	Repository::open()
      */
-    Repository Repository::create( const QString& path,
-                                   bool bare,
-                                   Result& result )
+    Repository Repository::create( Result& result,
+                                   const QString& path,
+                                   bool bare )
     {
         GW_CHECK_RESULT( result, Repository() );
 
@@ -178,10 +178,10 @@ namespace Git
      *
      * @see Repository::open(), Repository::create()
      */
-    QString Repository::discover( const QString& startPath,
+    QString Repository::discover( Result& result,
+                                  const QString& startPath,
                                   bool acrossFs,
-                                  const QStringList& ceilingDirs,
-                                  Result& result )
+                                  const QStringList& ceilingDirs )
     {
         GW_CHECK_RESULT( result, QString() );
 
@@ -219,8 +219,7 @@ namespace Git
      *
      * @sa	Repository::discover(), Repository::create()
      */
-    Repository Repository::open( const QString& path,
-                                 Result& result )
+    Repository Repository::open(Result& result, const QString& path)
     {
         GW_CHECK_RESULT( result, Repository() );
 
@@ -241,11 +240,10 @@ namespace Git
      *                  absolutely independant of this repository object.
      *
      * The repository is opened using the working directory path, not the .git path.
-     *
      */
     Repository Repository::reopen(Result& result) const
     {
-        return open(basePath(), result);
+        return open( result, basePath() );
     }
 
     /**
@@ -695,11 +693,6 @@ namespace Git
         return lookupTag(result, reference(result, refName).resolveToObjectId(result));
     }
 
-    RevisionWalker Repository::newWalker( Result& result )
-    {
-        return RevisionWalker::create(result, *this);
-    }
-
     bool Repository::shouldIgnore(Result& result, const QString& filePath) const
     {
         GW_CD_CHECKED(Repository, false, result);
@@ -792,12 +785,6 @@ namespace Git
         }
 
         return new Remote::Private(d.data(), remote);
-    }
-
-    Remote Repository::createRemote(Result& result, const QString& remoteName, const QString& url,
-                                    const QString& fetchSpec)
-    {
-        return Remote::create(result, *this, remoteName, url, fetchSpec);
     }
 
     DiffList Repository::diffCommitToCommit( Result& result, Commit oldCommit,
@@ -1081,5 +1068,57 @@ namespace Git
 
         return ref.asNote();
     }
+
+
+
+    // -- DEPRECATED FUNCTIONS BEGIN -->8
+
+    /**
+     * @brief           Repository::create
+     * @deprecated      Use @ref Repository::create(Result& result, const QString& path, bool bare) instead.
+     */
+    Repository Repository::create(const QString& path, bool bare, Result& result)
+    {
+        return create( result, path, bare );
+    }
+
+    /**
+     * @brief           Repository::discover
+     * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
+     */
+    QString Repository::discover(const QString& startPath, bool acrossFs, const QStringList& ceilingDirs, Git::Result& result)
+    {
+        return discover(result, startPath, acrossFs, ceilingDirs);
+    }
+
+    /**
+     * @brief           Repository::open
+     * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
+     */
+    Repository Repository::open(const QString &path, Result &result)
+    {
+        return open( result, path );
+    }
+
+    /**
+     * @brief           Repository::newWalker
+     * @deprecated      Use @ref RevisionWalker::create() instead.
+     */
+    RevisionWalker Repository::newWalker( Result& result )
+    {
+        return RevisionWalker::create(result, *this);
+    }
+
+    /**
+     * @brief           Repository::createRemote
+     * @deprecated      Use @ref Remote::create() instead.
+     */
+    Remote Repository::createRemote(Result& result, const QString& remoteName, const QString& url,
+                                    const QString& fetchSpec)
+    {
+        return Remote::create(result, *this, remoteName, url, fetchSpec);
+    }
+
+    // -- DEPRECATED FUNCTIONS END --<8
 
 }

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -895,11 +895,6 @@ namespace Git
         return headBranch(result).commitOperation( index(result), msg );
     }
 
-    Reference Repository::lookupRef(Result& result, const QString& refName, bool dwim)
-    {
-        return reference(result, refName, dwim);
-    }
-
     /**
      * @brief           Detach the current HEAD
      *
@@ -1058,66 +1053,5 @@ namespace Git
         // dwim doesn't work for notes
         return reference(result, QLatin1Literal("refs/notes/") % noteName).asNote();
     }
-
-
-
-    // -- DEPRECATED FUNCTIONS BEGIN -->8
-
-    /**
-     * @brief           Repository::create
-     * @deprecated      Use @ref Repository::create(Result& result, const QString& path, bool bare) instead.
-     */
-    Repository Repository::create(const QString& path, bool bare, Result& result)
-    {
-        return create( result, path, bare );
-    }
-
-    /**
-     * @brief           Repository::discover
-     * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
-     */
-    QString Repository::discover(const QString& startPath, bool acrossFs, const QStringList& ceilingDirs, Git::Result& result)
-    {
-        return discover(result, startPath, acrossFs, ceilingDirs);
-    }
-
-    /**
-     * @brief           Repository::open
-     * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
-     */
-    Repository Repository::open(const QString &path, Result &result)
-    {
-        return open( result, path );
-    }
-
-    /**
-     * @brief           Repository::newWalker
-     * @deprecated      Use @ref RevisionWalker::create() instead.
-     */
-    RevisionWalker Repository::newWalker( Result& result )
-    {
-        return RevisionWalker::create(result, *this);
-    }
-
-    /**
-     * @brief           Repository::createRemote
-     * @deprecated      Use @ref Remote::create() instead.
-     */
-    Remote Repository::createRemote(Result& result, const QString& remoteName, const QString& url,
-                                    const QString& fetchSpec)
-    {
-        return Remote::create(result, *this, remoteName, url, fetchSpec);
-    }
-
-    /**
-     * @brief Repository::renameBranch
-     * @deprecated      Use @ref Repository::renameBranch(Result& result, const QString& oldName, const QString& newName, bool force) instead.
-     */
-    bool Repository::renameBranch(const QString& oldName, const QString& newName, bool force, Git::Result& result)
-    {
-        return renameBranch( result, oldName, newName, force );
-    }
-
-    // -- DEPRECATED FUNCTIONS END --<8
 
 }

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -294,6 +294,7 @@ namespace Git
      */
     Index Repository::index( Result& result )
     {
+        GW_CHECK_RESULT( result, Index() );
         GW_D_CHECKED(Repository, Index(), result);
 
         if( isBare() ) {
@@ -329,20 +330,19 @@ namespace Git
      */
     Git::StatusFlags Repository::status(Result &result, const QString &fileName) const
     {
-        unsigned int status = GIT_STATUS_CURRENT;
+        GW_CHECK_RESULT( result, FileInvalidStatus );
         GW_CD_CHECKED(Repository, FileInvalidStatus, result);
 
+        unsigned int status = GIT_STATUS_CURRENT;
         result = git_status_file( &status, d->mRepo, GW_StringFromQt(fileName) );
-        if (!result) {
-            return FileInvalidStatus;
-        }
+        GW_CHECK_RESULT( result, FileInvalidStatus );
 
         return Internal::convertFileStatus( status );
     }
 
     StatusHash Repository::status(Result &result) const
     {
-        StatusHash sh;
+        GW_CHECK_RESULT( result, StatusHash() );
         GW_CD_CHECKED(Repository, StatusHash(), result);
 
         git_status_options opt = GIT_STATUS_OPTIONS_INIT;
@@ -352,11 +352,9 @@ namespace Git
                   | GIT_STATUS_OPT_INCLUDE_UNMODIFIED
                   | GIT_STATUS_OPT_RECURSE_UNTRACKED_DIRS;
 
+        StatusHash sh;
         result = git_status_foreach_ext( d->mRepo, &opt, &Internal::statusHashCB, (void*) &sh );
-        if( !result )
-        {
-            return Git::StatusHash();
-        }
+        GW_CHECK_RESULT( result, StatusHash() );
 
         return sh;
     }
@@ -371,27 +369,26 @@ namespace Git
      */
     QStringList Repository::allReferenceNames( Result& result )
     {
+        GW_CHECK_RESULT( result, QStringList() );
         GW_D_CHECKED(Repository, QStringList(), result);
 
         git_strarray arr;
         result = git_reference_list( &arr, d->mRepo );
-        if( !result )
-        {
-            return QStringList();
-        }
+        GW_CHECK_RESULT( result, QStringList() );
 
         return Internal::slFromStrArray( &arr );
     }
 
     ReferenceList Repository::allReferences(Result &result)
     {
+        GW_CHECK_RESULT( result, ReferenceList() );
         GW_D_CHECKED(Repository, ReferenceList(), result);
 
         Internal::cb_append_reference_data data = { d };
         result = git_reference_foreach( d->mRepo,
                                         &Internal::cb_append_reference,
                                         &data );
-        if (!result) return ReferenceList();
+        GW_CHECK_RESULT( result, ReferenceList() );
 
         return data.refs;
     }
@@ -430,6 +427,7 @@ namespace Git
 
     ResolvedRefs Repository::allResolvedRefs( Result& result )
     {
+        GW_CHECK_RESULT( result, ResolvedRefs() );
         GW_CD_CHECKED(Repository, ResolvedRefs(), result);
 
         Internal::cb_enum_resolvedrefs_data data;
@@ -459,13 +457,14 @@ namespace Git
     QString Repository::currentBranch(Result &result)
     {
         Reference refHEAD = HEAD( result );
-        if ( !refHEAD.isValid() ) return QString();
+        GW_CHECK_RESULT( result, QString() );
 
         return refHEAD.shorthand();
     }
 
     QStringList Repository::branchNames(Result& result, bool local, bool remote)
     {
+        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         QStringList sl;
@@ -507,9 +506,9 @@ namespace Git
         return sl;
     }
 
-    bool Repository::renameBranch( const QString& oldName, const QString& newName, bool force,
-                                   Result& result )
+    bool Repository::renameBranch(Result& result, const QString& oldName, const QString& newName, bool force)
     {
+        GW_CHECK_RESULT( result, false );
         GW_CD_CHECKED(Repository, false, result);
 
         git_reference* ref = NULL;
@@ -543,6 +542,7 @@ namespace Git
 
     QStringList Repository::allTagNames( Result& result )
     {
+        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         git_strarray arr;
@@ -608,15 +608,12 @@ namespace Git
 
     Reference Repository::HEAD( Result& result ) const
     {
+        GW_CHECK_RESULT( result, Reference() );
         GW_CD_EX_CHECKED(Repository, Reference(), result);
 
         git_reference* refHead = NULL;
-
         result = git_repository_head( &refHead, d->mRepo );
-        if( !result )
-        {
-            return Reference();
-        }
+        GW_CHECK_RESULT( result, Reference() );
 
         return Reference::PrivatePtr(new Reference::Private(PrivatePtr(d), refHead));
     }
@@ -637,6 +634,7 @@ namespace Git
 
     Object Repository::lookup( Result& result, const ObjectId& id, ObjectType ot )
     {
+        GW_CHECK_RESULT( result, Object() );
         GW_D_EX_CHECKED(Repository, Object(), result);
 
         git_object* obj = NULL;
@@ -695,6 +693,7 @@ namespace Git
 
     bool Repository::shouldIgnore(Result& result, const QString& filePath) const
     {
+        GW_CHECK_RESULT( result, false );
         GW_CD_CHECKED(Repository, false, result);
 
         int ignore = 0;
@@ -718,6 +717,7 @@ namespace Git
      */
     Remote::List Repository::allRemotes(Result& result) const
     {
+        GW_CHECK_RESULT( result, Remote::List() );
         GW_CD_EX_CHECKED(Repository, Remote::List(), result);
 
         git_strarray arr;
@@ -752,6 +752,7 @@ namespace Git
      */
     QStringList Repository::allRemoteNames( Result& result ) const
     {
+        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
 
         Internal::StrArray arr;
@@ -774,6 +775,7 @@ namespace Git
      */
     Remote Repository::remote(Result& result, const QString& remoteName) const
     {
+        GW_CHECK_RESULT( result, Remote() );
         GW_CD_EX_CHECKED(Repository, Remote(), result);
 
         git_remote* remote = NULL;
@@ -810,6 +812,7 @@ namespace Git
 
     DiffList Repository::diffIndexToWorkingDir( Result& result )
     {
+        GW_CHECK_RESULT( result, DiffList() );
         GW_D_EX_CHECKED(Repository, DiffList(), result);
 
         git_diff* diff = NULL;
@@ -852,33 +855,32 @@ namespace Git
 
     Submodule::List Repository::submodules( Result& result )
     {
+        GW_CHECK_RESULT( result, Submodule::List() );
         GW_D_CHECKED(Repository, Submodule::List(), result);
         Internal::cb_enum_submodules_t data = { d };
 
         result = git_submodule_foreach( d->mRepo, &Internal::cb_enum_submodules, &data );
-        if( !result )
-        {
-            return Submodule::List();
-        }
+        GW_CHECK_RESULT( result, Submodule::List() );
 
         return data.subs;
     }
 
     QStringList Repository::submoduleNames(Result& result) const
     {
+        GW_CHECK_RESULT( result, QStringList() );
         GW_CD_CHECKED(Repository, QStringList(), result);
+
         QStringList names;
 
         result = git_submodule_foreach(d->mRepo, &Internal::cb_enum_submodule_names, &names);
-        if (!result) {
-            return QStringList();
-        }
+        GW_CHECK_RESULT( result, QStringList() );
 
         return names;
     }
 
     Submodule Repository::submodule(Result& result, const QString& name) const
     {
+        GW_CHECK_RESULT( result, Submodule() );
         GW_CD_EX_CHECKED(Repository, Submodule(), result);
 
         if (submoduleNames(result).contains(name)) {
@@ -913,6 +915,7 @@ namespace Git
      */
     bool Repository::detachHead(Result& result)
     {
+        GW_CHECK_RESULT( result, false );
         GW_D_CHECKED(Repository, false, result);
 
         result = git_repository_detach_head( d->mRepo, NULL, NULL );
@@ -932,6 +935,7 @@ namespace Git
      */
     void Repository::setHEAD(Result& result, const QString& branchName)
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(Repository, void(), result);
 
         result = git_repository_set_head( d->mRepo, GW_StringFromQt(branchName), NULL, NULL );
@@ -947,11 +951,9 @@ namespace Git
      */
     void Repository::setHEAD(Result& result, const BranchRef& branch)
     {
-        if (!result) {
-            return;
-        }
+        GW_CHECK_RESULT( result, void() );
 
-        if (!branch.isValid()) {
+        if ( !branch.isValid() ) {
             result.setInvalidObject();
             return;
         }
@@ -1000,10 +1002,12 @@ namespace Git
     {
         GW_CD(Repository);
         if (!d) {
+            GitWrap::lastResult().setInvalidObject();
             return Submodule();
         }
 
         if (!d->openedFrom.isValid()) {
+            GitWrap::lastResult().setInvalidObject();
             return Submodule();
         }
 
@@ -1012,6 +1016,7 @@ namespace Git
 
     Reference Repository::reference(Result& result, const QString& refName, bool dwim)
     {
+        GW_CHECK_RESULT( result, Reference() );
         GW_D_CHECKED(Repository, Reference(), result);
 
         //GW_D_EX_CHECKED(Repository, Reference(), result);
@@ -1040,33 +1045,18 @@ namespace Git
 
     BranchRef Repository::branchRef(Result& result, const QString& branchName)
     {
-        Reference ref = reference(result, branchName, true);
-        if (!result) {
-            return BranchRef();
-        }
-
-        return ref.asBranch();
+        return reference(result, branchName, true).asBranch();
     }
 
     TagRef Repository::tagRef(Result& result, const QString& tagName)
     {
-        Reference ref = reference(result, tagName, true);
-        if (!result) {
-            return TagRef();
-        }
-
-        return ref.asTag();
+        return reference(result, tagName, true).asTag();
     }
 
     NoteRef Repository::noteRef(Result& result, const QString& noteName)
     {
-        // dwin doesn't work for notes
-        Reference ref = reference(result, QLatin1Literal("refs/notes/") % noteName);
-        if (!result) {
-            return NoteRef();
-        }
-
-        return ref.asNote();
+        // dwim doesn't work for notes
+        return reference(result, QLatin1Literal("refs/notes/") % noteName).asNote();
     }
 
 
@@ -1117,6 +1107,15 @@ namespace Git
                                     const QString& fetchSpec)
     {
         return Remote::create(result, *this, remoteName, url, fetchSpec);
+    }
+
+    /**
+     * @brief Repository::renameBranch
+     * @deprecated      Use @ref Repository::renameBranch(Result& result, const QString& oldName, const QString& newName, bool force) instead.
+     */
+    bool Repository::renameBranch(const QString& oldName, const QString& newName, bool force, Git::Result& result)
+    {
+        return renameBranch( result, oldName, newName, force );
     }
 
     // -- DEPRECATED FUNCTIONS END --<8

--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -991,7 +991,6 @@ namespace Git
     {
         GW_D_CHECKED(Repository, Reference(), result);
 
-        //GW_D_EX_CHECKED(Repository, Reference(), result);
         QString name = refName;
 
         git_reference* ref = NULL;

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -43,17 +43,22 @@ namespace Git
         GW_PRIVATE_DECL(Repository, Base, public)
 
     public:
-        static Repository create( const QString& path,
-                                  bool bare,
-                                  Result& result );
+        GW_DEPRECATED
+        static Repository create(const QString &path, bool bare, Result& result);
+        static Repository create(Result& result,
+                                 const QString& path,
+                                 bool bare);
 
-        static QString discover( const QString& startPath,
-                                 bool acrossFs /* = false */,
-                                 const QStringList& ceilingDirs /* = QStringList() */,
-                                 Result& result );
+        GW_DEPRECATED
+        static QString discover(const QString &startPath, bool acrossFs, const QStringList &ceilingDirs, Result& result);
+        static QString discover(Result& result , const QString& startPath,
+                                bool acrossFs = false,
+                                const QStringList& ceilingDirs = QStringList());
 
-        static Repository open( const QString& path,
-                                Result& result );
+        GW_DEPRECATED
+        static Repository open(const QString &path, Result& result);
+        static Repository open(Result& result,
+                               const QString& path );
 
         Repository reopen(Result& result) const;
 

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -87,9 +87,10 @@ namespace Git
 
         ResolvedRefs allResolvedRefs( Result& result );
 
-        // ### move to BranchRef
-        bool renameBranch( const QString& oldName, const QString& newName, bool force /* = false */,
-                           Result& result );
+        // TODO: move to BranchRef
+        GW_DEPRECATED
+        bool renameBranch(const QString &oldName, const QString &newName, bool force, Result& result);
+        bool renameBranch(Result& result, const QString& oldName, const QString& newName, bool force = false);
 
         Repository superproject() const;
         Submodule superprojectSubmodule() const;

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -21,6 +21,15 @@
 #include "libGitWrap/Remote.hpp"
 #include "libGitWrap/Object.hpp"
 
+
+// -- DEPRECATED INCLUDES BEGIN --8>
+
+#include "libGitWrap/RevisionWalker.hpp"
+#include "libGitWrap/Reference.hpp"
+
+// <8-- DEPRECATED INCLUDES END --
+
+
 namespace Git
 {
 
@@ -43,20 +52,14 @@ namespace Git
         GW_PRIVATE_DECL(Repository, Base, public)
 
     public:
-        GW_DEPRECATED
-        static Repository create(const QString &path, bool bare, Result& result);
         static Repository create(Result& result,
                                  const QString& path,
                                  bool bare);
 
-        GW_DEPRECATED
-        static QString discover(const QString &startPath, bool acrossFs, const QStringList &ceilingDirs, Result& result);
         static QString discover(Result& result , const QString& startPath,
                                 bool acrossFs = false,
                                 const QStringList& ceilingDirs = QStringList());
 
-        GW_DEPRECATED
-        static Repository open(const QString &path, Result& result);
         static Repository open(Result& result,
                                const QString& path );
 
@@ -88,8 +91,6 @@ namespace Git
         ResolvedRefs allResolvedRefs( Result& result );
 
         // TODO: move to BranchRef
-        GW_DEPRECATED
-        bool renameBranch(const QString &oldName, const QString &newName, bool force, Result& result);
         bool renameBranch(Result& result, const QString& oldName, const QString& newName, bool force = false);
 
         Repository superproject() const;
@@ -103,7 +104,6 @@ namespace Git
         Reference HEAD( Result& result ) const;
         BranchRef headBranch( Result& result ) const;
 
-        GW_DEPRECATED Reference lookupRef(Result& result, const QString& refName , bool dwim = false);
         ObjectId resolveRef(Result& result, const QString& refName);
 
         Reference reference(Result& result, const QString& refName, bool dwim = false);
@@ -111,8 +111,8 @@ namespace Git
         TagRef tagRef(Result& result, const QString& tagName);
         NoteRef noteRef(Result& result, const QString& noteName);
 
-        // ### Deprecate and name these: commit, tree, blob and tag.
-        // ### Figure out what the QString-overload should be useful for!
+        // TODO: Deprecate and name these: commit, tree, blob and tag.
+        // TODO: Figure out what the QString-overload should be useful for!
         Commit lookupCommit( Result& result, const ObjectId& id );
         Commit lookupCommit( Result& result, const QString& refName );
 
@@ -131,21 +131,15 @@ namespace Git
         template< class T >
         T lookup(Result& result, const ObjectId& id);
 
-        // ### Figure out, what this overload could be useful for!
+        // TODO: Figure out, what this overload could be useful for!
         template< class T >
         T lookup(Result& result, const QString& refName);
 
         bool shouldIgnore( Result& result, const QString& filePath ) const;
 
-        GW_DEPRECATED RevisionWalker newWalker(Result& result);
-
         QStringList allRemoteNames( Result& result ) const;
         Remote::List allRemotes(Result& result) const;
         Remote remote( Result& result, const QString& remoteName ) const;
-
-        GW_DEPRECATED
-        Remote createRemote(Result& result, const QString& remoteName, const QString& url,
-                            const QString& fetchSpec);
 
         DiffList diffCommitToCommit(Result& result, Commit oldCommit, Commit newCommit);
 
@@ -163,6 +157,82 @@ namespace Git
 
     public:
         CommitOperation* commitOperation(Result& result, const QString& msg);
+
+    public:
+        // -- DEPRECATED FUNCTIONS BEGIN --8>
+
+        /**
+         * @brief           Deprecated: Repository::create
+         * @deprecated      Use @ref Repository::create(Result& result, const QString& path, bool bare) instead.
+         */
+        GW_DEPRECATED
+        static Repository create(const QString& path, bool bare, Result& result)
+        {
+            return create( result, path, bare );
+        }
+
+        /**
+         * @brief           Deprecated: Repository::discover
+         * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
+         */
+        GW_DEPRECATED
+        static QString discover(const QString& startPath, bool acrossFs, const QStringList& ceilingDirs, Git::Result& result)
+        {
+            return discover(result, startPath, acrossFs, ceilingDirs);
+        }
+
+        /**
+         * @brief           Deprecated: Repository::open
+         * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
+         */
+        GW_DEPRECATED
+        static Repository open(const QString &path, Result &result)
+        {
+            return open( result, path );
+        }
+
+        /**
+         * @brief           Deprecated: Repository::newWalker
+         * @deprecated      Use @ref RevisionWalker::create() instead.
+         */
+        GW_DEPRECATED
+        inline RevisionWalker newWalker( Result& result )
+        {
+            return RevisionWalker::create(result, *this);
+        }
+
+        /**
+         * @brief           Deprecated: Repository::createRemote
+         * @deprecated      Use @ref Remote::create() instead.
+         */
+        GW_DEPRECATED
+        inline Remote createRemote(Result& result, const QString& remoteName, const QString& url,
+                                   const QString& fetchSpec)
+        {
+            return Remote::create(result, *this, remoteName, url, fetchSpec);
+        }
+
+        /**
+         * @brief           Deprecated: Repository::renameBranch
+         * @deprecated      Use @ref Repository::renameBranch(Result& result, const QString& oldName, const QString& newName, bool force) instead.
+         */
+        GW_DEPRECATED
+        inline bool renameBranch(const QString& oldName, const QString& newName, bool force, Git::Result& result)
+        {
+            return renameBranch( result, oldName, newName, force );
+        }
+
+        /**
+         * @brief           Deprecated: Repository::lookupRef
+         * @deprecated      Use @ref Repository::reference(Result& result, const QString& refName , bool dwim = false) instead.
+         */
+        GW_DEPRECATED
+        inline Reference lookupRef(Result& result, const QString& refName , bool dwim = false)
+        {
+            return reference( result, refName, dwim );
+        }
+
+        // -- DEPRECATED FUNCTIONS END --<8
     };
 
     template< class T >

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -183,7 +183,7 @@ namespace Git
 
         /**
          * @brief           Deprecated: Repository::open
-         * @deprecated      Use @ref Repository::create(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
+         * @deprecated      Use @ref Repository::open(Result& result, const QString& startPath, bool acrossFs, const QStringList& ceilingDirs) instead.
          */
         GW_DEPRECATED
         static Repository open(const QString &path, Result &result)

--- a/libGitWrap/Result.cpp
+++ b/libGitWrap/Result.cpp
@@ -34,6 +34,12 @@ namespace Git
      */
     void Result::setInvalidObject()
     {
+        if ( mCode )
+        {
+            // result is already set
+            return;
+        }
+
         mCode = -255;
         mClass = -1;
         mText = QLatin1String( "An invalid GitWrap object was used." );
@@ -48,6 +54,12 @@ namespace Git
      */
     void Result::setError( int resultCode )
     {
+        if ( mCode )
+        {
+            // result is already set
+            return;
+        }
+
         mCode = resultCode;
         if( mCode < 0 )
         {
@@ -79,6 +91,12 @@ namespace Git
      */
     void Result::setError(const char* szErrorText, int code)
     {
+        if ( mCode )
+        {
+            // result is already set
+            return;
+        }
+
         mClass = -1;
         mCode = code;
         mText = GW_StringToQt(szErrorText);

--- a/libGitWrap/Result.cpp
+++ b/libGitWrap/Result.cpp
@@ -25,6 +25,8 @@ namespace Git
      * @internal
      */
     Result::Result( int resultCode )
+        : mCode( 0 )
+        , mClass( 0 )
     {
         setError( resultCode );
     }

--- a/libGitWrap/Result.hpp
+++ b/libGitWrap/Result.hpp
@@ -71,6 +71,7 @@ namespace Git
      */
     inline Result::Result()
         : mCode( 0 )
+        , mClass( 0 )
     {
     }
 

--- a/libGitWrap/RevisionWalker.cpp
+++ b/libGitWrap/RevisionWalker.cpp
@@ -62,68 +62,58 @@ namespace Git
 
     void RevisionWalker::reset( Result& result )
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         git_revwalk_reset( d->mWalker );
     }
 
     void RevisionWalker::push(Result& result, const ObjectId& id)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_push( d->mWalker, (const git_oid*) id.raw() );
     }
 
     void RevisionWalker::push(Result& result, const Reference& ref)
     {
-        GW_CHECK_RESULT( result, void() );
         pushRef(result, ref.name());
     }
 
     void RevisionWalker::pushRef(Result& result, const QString& name)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_push_ref( d->mWalker, GW_StringFromQt(name) );
     }
 
     void RevisionWalker::pushHead( Result& result )
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_push_head( d->mWalker );
     }
 
     void RevisionWalker::hide( Result& result, const ObjectId& id )
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_hide( d->mWalker, (const git_oid*) id.raw() );
     }
 
     void RevisionWalker::hide(Result& result, const Reference& ref)
     {
-        GW_CHECK_RESULT( result, void() );
         hideRef(result, ref.name());
     }
 
     void RevisionWalker::hideRef(Result& result, const QString& name)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_hide_ref( d->mWalker, GW_StringFromQt(name) );
     }
 
     void RevisionWalker::hideHead( Result& result )
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_hide_head( d->mWalker );
     }
 
     bool RevisionWalker::next(Result& result, ObjectId& oidNext)
     {
-        GW_CHECK_RESULT( result, false );
         GW_D_CHECKED(RevisionWalker, false, result);
 
         git_oid oid;
@@ -145,7 +135,6 @@ namespace Git
 
     ObjectIdList RevisionWalker::all( Result& result )
     {
-        GW_CHECK_RESULT( result, ObjectIdList() );
         GW_D_CHECKED(RevisionWalker, ObjectIdList(), result);
         ObjectIdList ids;
         ObjectId id;
@@ -162,7 +151,6 @@ namespace Git
 
     void RevisionWalker::setSorting(Result& result, bool topological, bool timed)
     {
-        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         git_revwalk_sorting( d->mWalker,
                              ( topological ? GIT_SORT_TOPOLOGICAL : 0 ) |

--- a/libGitWrap/RevisionWalker.cpp
+++ b/libGitWrap/RevisionWalker.cpp
@@ -44,11 +44,10 @@ namespace Git
 
     RevisionWalker RevisionWalker::create(Result& result, const Repository& repository)
     {
-        if (!result) {
-            return RevisionWalker();
-        }
+        GW_CHECK_RESULT( result, RevisionWalker() );
 
         if (!repository) {
+            result.setInvalidObject();
             return RevisionWalker();
         }
 
@@ -56,68 +55,75 @@ namespace Git
         git_revwalk* walker = NULL;
 
         result = git_revwalk_new(&walker, rp->mRepo);
-
-        if (!result) {
-            return RevisionWalker();
-        }
+        GW_CHECK_RESULT( result, RevisionWalker() );
 
         return new RevisionWalker::Private(rp, walker);
     }
 
     void RevisionWalker::reset( Result& result )
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         git_revwalk_reset( d->mWalker );
     }
 
     void RevisionWalker::push(Result& result, const ObjectId& id)
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_push( d->mWalker, (const git_oid*) id.raw() );
     }
 
     void RevisionWalker::push(Result& result, const Reference& ref)
     {
+        GW_CHECK_RESULT( result, void() );
         pushRef(result, ref.name());
     }
 
     void RevisionWalker::pushRef(Result& result, const QString& name)
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_push_ref( d->mWalker, GW_StringFromQt(name) );
     }
 
     void RevisionWalker::pushHead( Result& result )
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_push_head( d->mWalker );
     }
 
     void RevisionWalker::hide( Result& result, const ObjectId& id )
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_hide( d->mWalker, (const git_oid*) id.raw() );
     }
 
     void RevisionWalker::hide(Result& result, const Reference& ref)
     {
+        GW_CHECK_RESULT( result, void() );
         hideRef(result, ref.name());
     }
 
     void RevisionWalker::hideRef(Result& result, const QString& name)
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_hide_ref( d->mWalker, GW_StringFromQt(name) );
     }
 
     void RevisionWalker::hideHead( Result& result )
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         result = git_revwalk_hide_head( d->mWalker );
     }
 
     bool RevisionWalker::next(Result& result, ObjectId& oidNext)
     {
+        GW_CHECK_RESULT( result, false );
         GW_D_CHECKED(RevisionWalker, false, result);
 
         git_oid oid;
@@ -126,6 +132,7 @@ namespace Git
         {
             return false;
         }
+
         if( !tmp )
         {
             result = tmp;
@@ -138,6 +145,7 @@ namespace Git
 
     ObjectIdList RevisionWalker::all( Result& result )
     {
+        GW_CHECK_RESULT( result, ObjectIdList() );
         GW_D_CHECKED(RevisionWalker, ObjectIdList(), result);
         ObjectIdList ids;
         ObjectId id;
@@ -154,6 +162,7 @@ namespace Git
 
     void RevisionWalker::setSorting(Result& result, bool topological, bool timed)
     {
+        GW_CHECK_RESULT( result, void() );
         GW_D_CHECKED(RevisionWalker, void(), result);
         git_revwalk_sorting( d->mWalker,
                              ( topological ? GIT_SORT_TOPOLOGICAL : 0 ) |

--- a/testGitWrap/Infra/TempRepo.cpp
+++ b/testGitWrap/Infra/TempRepo.cpp
@@ -38,7 +38,7 @@ TempRepo::~TempRepo()
 TempRepoOpener::TempRepoOpener(Fixture* fixture, const char* name, Git::Result& r)
     : mTempRepo(fixture, name)
 {
-    mRepo = Git::Repository::open(mTempRepo, r);
+    mRepo = Git::Repository::open( r, mTempRepo );
 }
 
 TempRepoOpener::~TempRepoOpener()


### PR DESCRIPTION
Cleanup our API convention.
- [x] In general all methods have to check on the `Result` and directly return, if false.
  - There are very few exceptions on that rule. For example, requesting the `Object.objectId()`, it will return an invalid objectId and set the result object.
- [x] Corrected API to take `Result` as first parameter. (Important: deprecate previous calls!)
- [x] Declare deprecated methods `inline` where possible.
- [x] Document deprecated functions.

:zap: It was not possible to inline the `Object::as...` methods, so I deleted them completely. They must not be used anyways.
