### PR TITLE
Fix missing string length

### DIFF
--- a/libGitWrap/DiffList.cpp
+++ b/libGitWrap/DiffList.cpp
@@ -161,7 +161,7 @@ namespace Git
                     --len;
                 }
 
-                ct = GW_StringToQt(line->content);
+                ct = GW_StringToQt(line->content, len);
             }
 
             switch(line->origin) {


### PR DESCRIPTION
This fixes an oversight introduced with the String-Macros. The side effect was actually interesting:

When selecting the commit that added the `gtest_all.cpp` file, MacGitver kept on allocating memory until the kernel finally started to puke... It looked like it was swapping. But I really cannot believe that:

For the Mac OS X kernel, this was interestingly around the area of 4GiB (2^32 bytes) - I have 16GiB and there are usually 10GiB free. My build is a 64 Bit build, so there should actually be no limit at that boundary. The address space is thus capable of allocating 2^32 chunks of 4 GiB.

However, MacGitver really _sucks_ at such big diffs, even with this fix. But I can't actually see how to improve on that. We need to copy and utf-8'ify the content from LG2, so we have 1 allocation per line.
