### PR TITLE
DPtr Magic

### DIFF
--- a/libGitWrap/Base.cpp
+++ b/libGitWrap/Base.cpp
@@ -73,8 +73,8 @@ namespace Git
          */
         bool BasePrivate::isValid(Result& r, const BasePrivate* d)
         {
-            if ( Q_LIKELY(d) ) {
-                return d->isValidObject( r );
+            if (Q_LIKELY(d)) {
+                return d->isValidObject(r);
             }
             r.setInvalidObject();
             return false;

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -49,6 +49,10 @@ namespace Git
     {
         GW_PRIVATE_DECL(Repository, Base, public)
 
+    private:
+        typedef DPtrT<      Repository>     DPtr;
+        typedef DPtrT<const Repository>     ConstDPtr;
+
     public:
         static Repository create(Result& result,
                                  const QString& path,
@@ -81,11 +85,11 @@ namespace Git
         QStringList allReferenceNames( Result& result );
         ReferenceList allReferences( Result& result );
 
-        QStringList allBranchNames( Result& result );
-        QStringList branchNames( Result& result, bool local, bool remote );
-        QString currentBranch( Result& result );
+        QStringList allBranchNames( Result& result ) const;
+        QStringList branchNames( Result& result, bool local, bool remote ) const;
+        QString currentBranch( Result& result ) const;
 
-        QStringList allTagNames( Result& result );
+        QStringList allTagNames( Result& result ) const;
 
         ResolvedRefs allResolvedRefs( Result& result );
 

--- a/libGitWrap/Result.hpp
+++ b/libGitWrap/Result.hpp
@@ -18,7 +18,6 @@
 
 #include "libGitWrap/GitWrap.hpp"
 
-
 namespace Git
 {
 


### PR DESCRIPTION
@antis81

This began as playing around with the D-Pointers for RepoMan. What I wanted to achieve is to get a solution to have concretely casted D-Pointers without the usage of the preprocessor macros. This is more or less what I ended up with.

Turned out, that esp. in libGitWrap, we have to do the required D-Ptr test quite often even though we might have actually concluded that it is redundant. However, with this approach we can optimise the code flow for the most likely path. i.e.:

``` C++
QStringList X::getSomeData(Result& res) const {
    QStringList sl;
    ConstDPtr d(this, result);
    if (d) {
        git_strarray a;
        result = git_get_some_data(d->mRepo, &a);
        if (result) {
            QStringList sl = wrapIt(a);
            git_strarray_free(&a);
            return sl;
        }
    }
    return QStringList();
}
```
