### PR TITLE
Operations: transform CloneOperation back to simple static method

### DIFF
--- a/libGitWrap/Repository.cpp
+++ b/libGitWrap/Repository.cpp
@@ -172,6 +172,30 @@ namespace Git
      */
 
     /**
+     * @brief           Clone a Git repository.
+     *
+     * @param[in,out]	result  A Result object; see @ref GitWrapErrorHandling
+     *
+     * @param[in]       from    the URL to clone from
+     *
+     * @param[in]       to      the path to clone to
+     *
+     * @return          the cloned repository
+     */
+    Repository Repository::clone(Result& result, const QString& from, const QString& to)
+    {
+        GW_CHECK_RESULT(result, nullptr);
+
+        // TODO: setup clone options and callbacks
+
+        git_repository* clonedRepo = nullptr;
+        result = git_clone(&clonedRepo, GW_StringFromQt(from), GW_StringFromQt(to), nullptr /*TODO: clone options*/);
+        GW_CHECK_RESULT(result, nullptr);
+
+        return new Private(clonedRepo);
+    }
+
+    /**
      * @brief       Create a new repository
      *
      * A new git repository will be created in @a path. The path pointed to by @a path must either

--- a/libGitWrap/Repository.hpp
+++ b/libGitWrap/Repository.hpp
@@ -43,6 +43,11 @@ namespace Git
         GW_PRIVATE_DECL(Repository, Base, public)
 
     public:
+        static Repository clone(Result& result,
+                                const QString& from,
+                                const QString& to
+                                /*TODO: options*/);
+
         static Repository create(Result& result,
                                  const QString& path,
                                  bool bare);


### PR DESCRIPTION
@scunz Can you please review and confirm, that this matches your imagination? If so, I'll go on transforming the former CloneOperation, preparing it for our planned MGV-Service.

Things to do after the above is confirmed:
- [ ] transport the callbacks from `Git::CloneOperation`
- [ ] abstract `git_clone_options` to public `Git::CloneOptions`, making them available to the public API
  - Roughly spoken, the former `Git::CloneOperation::setSomeCloneOption` methods have to be extracted into a new public `Git::CloneOptions` class or struct. 
